### PR TITLE
support bfrange array

### DIFF
--- a/page.go
+++ b/page.go
@@ -311,6 +311,13 @@ Parse:
 								continue Parse
 							}
 							if bfrange.dst.Kind() == Array {
+								n := text[len(text)-1] - bfrange.lo[len(bfrange.lo)-1]
+								v := bfrange.dst.Index(int(n))
+								if v.Kind() == String {
+									s := v.RawString()
+									r = append(r, []rune(utf16Decode(s))...)
+									continue Parse
+								}
 								fmt.Printf("array %v\n", bfrange.dst)
 							} else {
 								fmt.Printf("unknown dst %v\n", bfrange.dst)


### PR DESCRIPTION
According to 5014.CIDFont_Spec pp.72, `bfrange` may array values as a mapping.
https://www.adobe.com/content/dam/acom/en/devnet/font/pdfs/5014.CIDFont_Spec.pdf