### PR TITLE
fix infinit loop

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -225,7 +225,7 @@ func (b *buffer) readLiteralString() token {
 	tmp := b.tmp[:0]
 	depth := 1
 Loop:
-	for {
+	for !b.eof {
 		c := b.readByte()
 		switch c {
 		default:


### PR DESCRIPTION
Hello!
There is possible infinit loop when we are iterating over bytes of a buffer. On some pdf files we endlessly calling function reload() when b.pos = 0 and len(b.buf) = 0, so I think it is better to check for end of file as well.