### PR TITLE
support array of content streams and parse them as a single stream

### DIFF
--- a/page.go
+++ b/page.go
@@ -779,7 +779,17 @@ func (p Page) walkTextBlocks(walker func(enc TextEncoding, x, y float64, s strin
 
 // Content returns the page's content.
 func (p Page) Content() Content {
-	strm := p.V.Key("Contents")
+	v := p.V.Key("Contents")
+
+	// The Contents key can either be a stream or an array of streams
+	if v.Kind() == Stream || v.Kind() == Array {
+		return p.content(v)
+	} else {
+		panic("unsupported value kind in Contents key")
+	}
+}
+
+func (p Page) content(strm Value) Content {
 	var enc TextEncoding = &nopEncoder{}
 
 	var g = gstate{
@@ -814,7 +824,7 @@ func (p Page) Content() Content {
 
 	var rect []Rect
 	var gstack []gstate
-	Interpret(strm, func(stk *Stack, op string) {
+	do := func(stk *Stack, op string) {
 		n := stk.Len()
 		args := make([]Value, n)
 		for i := n - 1; i >= 0; i-- {
@@ -995,7 +1005,12 @@ func (p Page) Content() Content {
 			}
 			g.Th = args[0].Float64() / 100
 		}
-	})
+	}
+	if strm.Kind() == Stream {
+		Interpret(strm, do)
+	} else {
+		InterpretArray(strm, do)
+	}
 	return Content{text, rect}
 }
 

--- a/page.go
+++ b/page.go
@@ -779,17 +779,7 @@ func (p Page) walkTextBlocks(walker func(enc TextEncoding, x, y float64, s strin
 
 // Content returns the page's content.
 func (p Page) Content() Content {
-	v := p.V.Key("Contents")
-
-	// The Contents key can either be a stream or an array of streams
-	if v.Kind() == Stream || v.Kind() == Array {
-		return p.content(v)
-	} else {
-		panic("unsupported value kind in Contents key")
-	}
-}
-
-func (p Page) content(strm Value) Content {
+	strm := p.V.Key("Contents")
 	var enc TextEncoding = &nopEncoder{}
 
 	var g = gstate{
@@ -824,7 +814,7 @@ func (p Page) content(strm Value) Content {
 
 	var rect []Rect
 	var gstack []gstate
-	do := func(stk *Stack, op string) {
+	Interpret(strm, func(stk *Stack, op string) {
 		n := stk.Len()
 		args := make([]Value, n)
 		for i := n - 1; i >= 0; i-- {
@@ -1005,12 +995,7 @@ func (p Page) content(strm Value) Content {
 			}
 			g.Th = args[0].Float64() / 100
 		}
-	}
-	if strm.Kind() == Stream {
-		Interpret(strm, do)
-	} else {
-		InterpretArray(strm, do)
-	}
+	})
 	return Content{text, rect}
 }
 

--- a/ps.go
+++ b/ps.go
@@ -49,91 +49,31 @@ func newDict() Value {
 // in PDF files, such as cmap files that describe the mapping from font code
 // points to Unicode code points.
 //
-// There is no support for executable blocks, among other limitations.
+// A stream can also be represented by an array of streams that has to be handled as a single stream
+// In the case of a simple stream read only once, otherwise get the length of the stream to handle it properly
 //
+// There is no support for executable blocks, among other limitations.
 func Interpret(strm Value, do func(stk *Stack, op string)) {
-	rd := strm.Reader()
-	b := newBuffer(rd, 0)
-	b.allowEOF = true
-	b.allowObjptr = false
-	b.allowStream = false
 	var stk Stack
 	var dicts []dict
-Reading:
-	for {
-		tok := b.readToken()
-		if tok == io.EOF {
-			break
-		}
-		if kw, ok := tok.(keyword); ok {
-			switch kw {
-			case "null", "[", "]", "<<", ">>":
-				break
-			default:
-				for i := len(dicts) - 1; i >= 0; i-- {
-					if v, ok := dicts[i][name(kw)]; ok {
-						stk.Push(Value{nil, objptr{}, v})
-						continue Reading
-					}
-				}
-				do(&stk, string(kw))
-				continue
-			case "dict":
-				stk.Pop()
-				stk.Push(Value{nil, objptr{}, make(dict)})
-				continue
-			case "currentdict":
-				if len(dicts) == 0 {
-					panic("no current dictionary")
-				}
-				stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
-				continue
-			case "begin":
-				d := stk.Pop()
-				if d.Kind() != Dict {
-					panic("cannot begin non-dict")
-				}
-				dicts = append(dicts, d.data.(dict))
-				continue
-			case "end":
-				if len(dicts) <= 0 {
-					panic("mismatched begin/end")
-				}
-				dicts = dicts[:len(dicts)-1]
-				continue
-			case "def":
-				if len(dicts) <= 0 {
-					panic("def without open dict")
-				}
-				val := stk.Pop()
-				key, ok := stk.Pop().data.(name)
-				if !ok {
-					panic("def of non-name")
-				}
-				dicts[len(dicts)-1][key] = val.data
-				continue
-			case "pop":
-				stk.Pop()
-				continue
-			}
-		}
-		b.unreadToken(tok)
-		obj := b.readObject()
-		stk.Push(Value{nil, objptr{}, obj})
+	s := strm
+	strmlen := 1
+	if strm.Kind() == Array {
+		strmlen = strm.Len()
 	}
-}
 
-// Interpret an array of streams as a single stream
-func InterpretArray(strms Value, do func(stk *Stack, op string)) {
-	var stk Stack
-	var dicts []dict
-	for i := 0; i < strms.Len(); i++ {
-		s := strms.Index(i)
+	for i := 0; i < strmlen; i++ {
+		if strm.Kind() == Array {
+			s = strm.Index(i)
+		}
+
 		rd := s.Reader()
+
 		b := newBuffer(rd, 0)
 		b.allowEOF = true
 		b.allowObjptr = false
 		b.allowStream = false
+
 	Reading:
 		for {
 			tok := b.readToken()
@@ -197,7 +137,6 @@ func InterpretArray(strms Value, do func(stk *Stack, op string)) {
 			stk.Push(Value{nil, objptr{}, obj})
 		}
 	}
-
 }
 
 type seqReader struct {

--- a/ps.go
+++ b/ps.go
@@ -123,6 +123,83 @@ Reading:
 	}
 }
 
+// Interpret an array of streams as a single stream
+func InterpretArray(strms Value, do func(stk *Stack, op string)) {
+	var stk Stack
+	var dicts []dict
+	for i := 0; i < strms.Len(); i++ {
+		s := strms.Index(i)
+		rd := s.Reader()
+		b := newBuffer(rd, 0)
+		b.allowEOF = true
+		b.allowObjptr = false
+		b.allowStream = false
+	Reading:
+		for {
+			tok := b.readToken()
+			if tok == io.EOF {
+				break
+			}
+			if kw, ok := tok.(keyword); ok {
+				switch kw {
+				case "null", "[", "]", "<<", ">>":
+					break
+				default:
+					for i := len(dicts) - 1; i >= 0; i-- {
+						if v, ok := dicts[i][name(kw)]; ok {
+							stk.Push(Value{nil, objptr{}, v})
+							continue Reading
+						}
+					}
+					do(&stk, string(kw))
+					continue
+				case "dict":
+					stk.Pop()
+					stk.Push(Value{nil, objptr{}, make(dict)})
+					continue
+				case "currentdict":
+					if len(dicts) == 0 {
+						panic("no current dictionary")
+					}
+					stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
+					continue
+				case "begin":
+					d := stk.Pop()
+					if d.Kind() != Dict {
+						panic("cannot begin non-dict")
+					}
+					dicts = append(dicts, d.data.(dict))
+					continue
+				case "end":
+					if len(dicts) <= 0 {
+						panic("mismatched begin/end")
+					}
+					dicts = dicts[:len(dicts)-1]
+					continue
+				case "def":
+					if len(dicts) <= 0 {
+						panic("def without open dict")
+					}
+					val := stk.Pop()
+					key, ok := stk.Pop().data.(name)
+					if !ok {
+						panic("def of non-name")
+					}
+					dicts[len(dicts)-1][key] = val.data
+					continue
+				case "pop":
+					stk.Pop()
+					continue
+				}
+			}
+			b.unreadToken(tok)
+			obj := b.readObject()
+			stk.Push(Value{nil, objptr{}, obj})
+		}
+	}
+
+}
+
 type seqReader struct {
 	rd     io.Reader
 	offset int64


### PR DESCRIPTION
Support array of content streams.

this is based on some work in 
- https://github.com/ledongthuc/pdf/pull/32
- https://github.com/oxisto/pdf/commit/22dd2375e784bfe8a73e2ecbc294984c110a55bd

but, as far as I understand the spec, the streams have to be concatenated before they are interpreted i.e. they have to be interpreted as a single stream. Otherwise some streams might be invalid as they depend on e.g. BT ops being opened in the previous stream.

![grafik](https://github.com/ledongthuc/pdf/assets/94619326/bc6c8ea3-38b2-43c1-a6ac-4100ff7e78f9)
https://opensource.adobe.com/dc-acrobat-sdk-docs/pdfstandards/PDF32000_2008.pdf (page 78)

This draft includes some duplication that could be refactored, but I don't have the full visibility of the code base (yet).

In addition I think that other functions like walkTextBlocks might have to be updated as well.
