### PR TITLE
Handle "stream not present" error in buffer reload to mark EOF

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -7,6 +7,7 @@
 package pdf
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -87,6 +88,10 @@ func (b *buffer) reload() bool {
 	if n == 0 && err != nil {
 		b.buf = b.buf[:0]
 		b.pos = 0
+		if errors.Is(err, fmt.Errorf("stream not present")) {
+			b.eof = true
+			return false
+		}
 		if b.allowEOF && err == io.EOF {
 			b.eof = true
 			return false


### PR DESCRIPTION
I was trying to read a pdf and it went in an infinite loop, on debugging i found that "stream not present" error was not handled, can you verify if this is a correct fix 