### PR TITLE
Bugfix: avoid OOM kill while handling arrays that are spanning multiple streams

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -469,6 +469,13 @@ func (b *buffer) readArray() object {
 		if tok == nil || tok == keyword("]") {
 			break
 		}
+		if err, ok := tok.(error); ok && err == io.EOF {
+			// whenever the buffer b is empty it constantly outputs
+			// io.EOF which is then continuously appended to the array x.
+			// this goes on until an OOM kill by the OS.
+			// break this inifinte loop and avoid an OOM kill.
+			break
+		}
 		b.unreadToken(tok)
 		x = append(x, b.readObject())
 	}


### PR DESCRIPTION
previously there was a bug which occurred when an array was starting in a stream and continue into the next stream.
in such case the readArray() method got stuck in an infinite loop and constantly appended io.EOF to an array - which consumes all the available memory until an OOM kill by the OS.
the bug was addressed in 2 manners, one it to check for errors in the readArray() method.
the other was to concatenate the streams so the Interpret function could handle (rather than just ignore) those kind of arrays.