### PR TITLE
fix: handle EOF and ] keyword

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -418,8 +418,8 @@ func (b *buffer) readObject() object {
 			return b.readDict()
 		case "[":
 			return b.readArray()
-		case ">>":
-			// stop the object
+		case ">>", "]":
+			// stop the object - these mark the end of dict/array
 			return nil
 		}
 		b.errorf("unexpected keyword %q parsing object", kw)
@@ -466,7 +466,7 @@ func (b *buffer) readArray() object {
 	var x array
 	for {
 		tok := b.readToken()
-		if tok == nil || tok == keyword("]") {
+		if tok == nil || tok == io.EOF || tok == keyword("]") {
 			break
 		}
 		b.unreadToken(tok)


### PR DESCRIPTION
Hi there,

I stumbled upon an issue with the library not gracefully handling EOF and the "`]`" keyword. Here's a PR to fix that problem.

The lib doesn't have any tests, so I didn't add any to this PR, assuming that's on purpose, but I attached them here to this PR for reference. Also, here's a PDF file that failed previously before this fix.

[Archive.zip](https://github.com/user-attachments/files/24647135/Archive.zip)
