### PR TITLE
fix: add maximum nesting depth for PDF object parsing

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -30,6 +30,12 @@ type name string
 // such as "<<", ">>", "[", "]", "{", "}", are also treated as keywords.
 type keyword string
 
+// maxObjectDepth is the maximum nesting depth for PDF objects (dicts, arrays,
+// and indirect object definitions). Malicious files can nest millions of
+// "N N obj" tokens to exhaust the Go call stack; this limit turns that into
+// a recoverable panic instead of a fatal process crash.
+const maxObjectDepth = 1000
+
 // A buffer holds buffered input bytes from the PDF file.
 type buffer struct {
 	r           io.Reader // source of data
@@ -45,6 +51,7 @@ type buffer struct {
 	key         []byte
 	useAES      bool
 	objptr      objptr
+	depth       int // current object nesting depth
 }
 
 // newBuffer returns a new buffer reading from r at the given offset.
@@ -409,6 +416,13 @@ type objdef struct {
 }
 
 func (b *buffer) readObject() object {
+	b.depth++
+	defer func() { b.depth-- }()
+	if b.depth > maxObjectDepth {
+		b.errorf("object nesting exceeds maximum depth %d", maxObjectDepth)
+		return nil
+	}
+
 	tok := b.readToken()
 	if kw, ok := tok.(keyword); ok {
 		switch kw {

--- a/read.go
+++ b/read.go
@@ -130,7 +130,18 @@ func NewReader(f io.ReaderAt, size int64) (*Reader, error) {
 // If the PDF is encrypted, NewReaderEncrypted calls pw repeatedly to obtain passwords
 // to try. If pw returns the empty string, NewReaderEncrypted stops trying to decrypt
 // the file and returns an error.
-func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, error) {
+func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (r *Reader, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			r = nil
+			if e, ok := x.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("malformed PDF: %v", x)
+			}
+		}
+	}()
+
 	buf := make([]byte, 10)
 	f.ReadAt(buf, 0)
 	if !bytes.HasPrefix(buf, []byte("%PDF-1.")) || buf[7] < '0' || buf[7] > '7' || buf[8] != '\r' && buf[8] != '\n' {
@@ -152,7 +163,7 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 		return nil, fmt.Errorf("malformed PDF file: missing final startxref")
 	}
 
-	r := &Reader{
+	r = &Reader{
 		f:   f,
 		end: end,
 	}

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,153 @@
+package pdf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadObjectMaxDepth(t *testing.T) {
+	// Craft a payload of deeply nested "0 0 obj" sequences that would
+	// previously cause unbounded recursion and a fatal stack overflow.
+	// With the depth limit in place this must produce a recoverable panic
+	// (caught here) instead of crashing the process.
+	const depth = maxObjectDepth + 100
+	var payload bytes.Buffer
+	for i := 0; i < depth; i++ {
+		payload.WriteString("0 0 obj\n")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	var panicMsg string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+				panicMsg = r.(error).Error()
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested objects, but readObject returned normally")
+	}
+	if !strings.Contains(panicMsg, "maximum depth") {
+		t.Fatalf("expected 'maximum depth' in panic message, got: %s", panicMsg)
+	}
+}
+
+func TestReadDictMaxDepth(t *testing.T) {
+	// Deeply nested dictionaries: << /A << /A << ... >> >> >>
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested dicts, but readObject returned normally")
+	}
+}
+
+func TestReadArrayMaxDepth(t *testing.T) {
+	// Deeply nested arrays: [ [ [ ... ] ] ]
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("[ ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" ]")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested arrays, but readObject returned normally")
+	}
+}
+
+func TestReadObjectNormalDepth(t *testing.T) {
+	// A moderately nested structure should parse without hitting the limit.
+	var payload bytes.Buffer
+	const depth = 50
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("(hello)")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		obj := b.readObject()
+		if obj == nil {
+			t.Fatal("expected non-nil object from moderately nested dict")
+		}
+	}()
+
+	if panicked {
+		t.Fatal("unexpected panic from moderately nested dicts")
+	}
+}
+
+func TestNewReaderMaliciousPDF(t *testing.T) {
+	// Reproduce the exact attack vector from MM-63434: a PDF with millions
+	// of "0 0 obj" tokens that triggers deep recursion during NewReader's
+	// xref parsing. With the fix, NewReader should return an error (via
+	// recovered panic) rather than crashing the process.
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.0\n")
+	for i := 0; i < 10_000; i++ {
+		pdf.WriteString("0\n0\nobj\n")
+	}
+	pdf.WriteString("startxref\n0\n%%EOF\n")
+
+	data := pdf.Bytes()
+	_, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error from malicious PDF, got nil")
+	}
+}


### PR DESCRIPTION
## Summary
Limit the recursion depth in readObject() to prevent excessive resource consumption when parsing deeply nested PDF structures. Returns an error if parsing past the limit (1000 objects).

This prevents stack overflow on recursively nested PDF objects.

## Testing
Added read_test.go with go test coverage for object/dict/array nesting beyond the new limit. 