### PR TITLE
feat: add support for "GBK-EUC-H"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/ledongthuc/pdf
 
-go 1.24.1
+go 1.25.0
+
+require golang.org/x/text v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=

--- a/page.go
+++ b/page.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/simplifiedchinese"
 )
 
 // A Page represent a single page in a PDF file.
@@ -210,6 +213,8 @@ func (f Font) getEncoder() TextEncoding {
 			return &byteEncoder{&macRomanEncoding}
 		case "Identity-H":
 			return f.charmapEncoding()
+		case "GBK-EUC-H":
+			return newGBKEncoder()
 		default:
 			if DebugOn {
 				println("unknown encoding", enc.Name())
@@ -285,6 +290,26 @@ type nopEncoder struct {
 
 func (e *nopEncoder) Decode(raw string) (text string) {
 	return raw
+}
+
+func newGBKEncoder() TextEncoding {
+	return &chineseEncoder{decoder: simplifiedchinese.GBK.NewDecoder()}
+}
+
+type chineseEncoder struct {
+	decoder *encoding.Decoder
+}
+
+func (e *chineseEncoder) Decode(raw string) (text string) {
+	var err error
+	text, err = e.decoder.String(raw)
+	if err != nil {
+		if DebugOn {
+			println("GBK decode error:", err)
+		}
+		return raw
+	}
+	return text
 }
 
 type byteEncoder struct {


### PR DESCRIPTION
Raw file part:

```pdf
14 0 obj
<< /Annots [ 6 0 R ] /Contents [ 18 0 R 19 0 R 20 0 R ] /CropBox [ 0 561.26 595.276 841.89 ] /MediaBox [ 0 0 595.276 841.89 ] /Parent 8 0 R /Resources << /Font << /KSPF1 21 0 R /KSPF14 22 0 R /KSPF15 23 0 R /KSPF2 24 0 R /KSPF3 25 0 R /KSPF31 26 0 R /KSPF4 27 0 R /KSPF5 28 0 R /KSPF6 29 0 R /KSPF7 30 0 R >> /XObject << /KSPX16 31 0 R /Xi0 32 0 R /Xi1 33 0 R /Xi10 34 0 R /Xi11 35 0 R /Xi12 36 0 R /Xi13 37 0 R /Xi14 38 0 R /Xi15 39 0 R /Xi16 40 0 R /Xi17 41 0 R /Xi18 42 0 R /Xi19 43 0 R /Xi2 44 0 R /Xi20 45 0 R /Xi21 46 0 R /Xi3 47 0 R /Xi4 48 0 R /Xi5 49 0 R /Xi6 50 0 R /Xi7 51 0 R /Xi8 52 0 R /Xi9 53 0 R >> >> /Type /Page >>
endobj

19 0 obj
<< /Length 5147 >>
stream
q
BT
/KSPF5 14.00 Tf
2 Tr
0.400 w
1 0 0 1 259.171814 805.561462  Tm
0 0 0 rg
0 0 0 RG
[<cda8d3c3>] TJ
ET

% ...
Q

endstream
endobj

28 0 obj
<< /BaseFont /SimSun /DescendantFonts [ 61 0 R ] /Encoding /GBK-EUC-H /Subtype /Type0 /Type /Font >>
endobj

61 0 obj
<< /BaseFont /SimSun /CIDSystemInfo << /Ordering (GB1) /Registry (Adobe) /Supplement 2 >> /FontDescriptor 69 0 R /Subtype /CIDFontType2 /Type /Font /W [ 7716 7716 500 814 907 500 ] >>
endobj
```