### PR TITLE
feat: CMap variants, Metadata API, Outline page numbers, Context cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,14 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.24'
+        go-version: '1.25'
         cache: true
 
     - name: Install dependencies
       run: go mod download
 
-    - name: Run tests
-      run: go test -v ./...
-
     - name: Build
-      run: go build -v ./... 
+      run: go build -v ./...
+
+    - name: Run tests
+      run: go test -race -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 CLAUDE.md
 .docgraph/
+.claude/
+plans/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+CLAUDE.md
+.docgraph/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # PDF Reader
 
+[![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
+[![Go Reference](https://pkg.go.dev/badge/github.com/Detective-XH/pdf.svg)](https://pkg.go.dev/github.com/Detective-XH/pdf)
+
 A Go library for reading PDF files, with active CJK text extraction support.
 
 Forked from [ledongthuc/pdf](https://github.com/ledongthuc/pdf) (upstream inactive since 2024).

--- a/README.md
+++ b/README.md
@@ -1,25 +1,42 @@
 # PDF Reader
 
-[![Built with WeBuild](https://raw.githubusercontent.com/webuild-community/badge/master/svg/WeBuild.svg)](https://webuild.community)
+A Go library for reading PDF files, with active CJK text extraction support.
 
-A simple Go library which enables reading PDF files. Forked from https://github.com/rsc/pdf
+Forked from [ledongthuc/pdf](https://github.com/ledongthuc/pdf) (upstream inactive since 2024).
+Original lineage: [rsc/pdf](https://github.com/rsc/pdf).
 
-Features
-  - Get plain text content (without format)
-  - Get Content (including all font and formatting information)
+## Features
 
-## Install:
+- Plain text extraction (no formatting)
+- Styled text extraction (font name, size, position)
+- Text grouped by row
+- **CJK predefined CMap decoders** (added in this fork):
+  - Japanese Shift-JIS (`90ms-RKSJ-H/V`, `90pv-RKSJ-H`)
+  - CJK UCS-2 BE (`UniGB-UCS2-H/V`, `UniCNS-UCS2-H/V`, `UniJIS-UCS2-H/V`, `UniKS-UCS2-H/V`)
+  - Simplified Chinese GBK (`GBK-EUC-H/V`)
+  - Traditional Chinese Big5-ETen (`ETen-B5-H/V`)
+  - Korean UHC/EUC-KR (`KSCms-UHC-H/V`)
 
-`go get -u github.com/ledongthuc/pdf`
+## Install
 
-## Examples:
+```bash
+go get github.com/Detective-XH/pdf
+```
 
- - Check in examples/ folder
+To use this fork in a project that already depends on `ledongthuc/pdf`, add a
+`replace` directive:
 
+```
+replace github.com/ledongthuc/pdf => github.com/Detective-XH/pdf v0.0.0-latest
+```
 
-## Read plain text
+## Examples
 
-```golang
+See the `examples/` folder for runnable programs.
+
+### Read plain text
+
+```go
 package main
 
 import (
@@ -30,9 +47,7 @@ import (
 )
 
 func main() {
-	pdf.DebugOn = true
-
-	f, r, err := pdf.Open("./pdf_test.pdf")
+	f, r, err := pdf.Open("./sample.pdf")
 	if err != nil {
 		panic(err)
 	}
@@ -44,14 +59,13 @@ func main() {
 		panic(err)
 	}
 	buf.ReadFrom(b)
-	content := buf.String()
-	fmt.Println(content)
+	fmt.Println(buf.String())
 }
 ```
 
-## Read all text with styles from PDF
+### Read styled text
 
-```golang
+```go
 package main
 
 import (
@@ -61,7 +75,7 @@ import (
 )
 
 func main() {
-	f, r, err := pdf.Open("./pdf_test.pdf")
+	f, r, err := pdf.Open("./sample.pdf")
 	if err != nil {
 		panic(err)
 	}
@@ -71,23 +85,16 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-
-	// Print all sentences
-	for _, sentence := range sentences {
-		fmt.Printf("Font: %s, Font-size: %f, x: %f, y: %f, content: %s \n",
-			sentence.Font,
-			sentence.FontSize,
-			sentence.X,
-			sentence.Y,
-			sentence.S)
+	for _, s := range sentences {
+		fmt.Printf("font=%s size=%.1f x=%.1f y=%.1f text=%s\n",
+			s.Font, s.FontSize, s.X, s.Y, s.S)
 	}
 }
 ```
 
+### Read text by row
 
-## Read text grouped by rows
-
-```golang
+```go
 package main
 
 import (
@@ -98,41 +105,37 @@ import (
 )
 
 func main() {
-	content, err := readPdf(os.Args[1]) // Read local pdf file
+	f, r, err := pdf.Open(os.Args[1])
 	if err != nil {
 		panic(err)
 	}
-	fmt.Println(content)
-	return
-}
+	defer f.Close()
 
-func readPdf(path string) (string, error) {
-	f, r, err := pdf.Open(path)
-	defer func() {
-		_ = f.Close()
-	}()
-	if err != nil {
-		return "", err
-	}
-	totalPage := r.NumPage()
-
-	for pageIndex := 1; pageIndex <= totalPage; pageIndex++ {
-		p := r.Page(pageIndex)
-		if p.V.IsNull() || p.V.Key("Contents").Kind() == pdf.Null {
+	for i := 1; i <= r.NumPage(); i++ {
+		p := r.Page(i)
+		if p.V.IsNull() {
 			continue
 		}
-
 		rows, _ := p.GetTextByRow()
 		for _, row := range rows {
-		    println(">>>> row: ", row.Position)
-		    for _, word := range row.Content {
-		        fmt.Println(word.S)
-		    }
+			fmt.Printf("row %d:", row.Position)
+			for _, word := range row.Content {
+				fmt.Printf(" %s", word.S)
+			}
+			fmt.Println()
 		}
 	}
-	return "", nil
 }
 ```
 
-## Demo
-![Run example](https://i.gyazo.com/01fbc539e9872593e0ff6bac7e954e6d.gif)
+## Fork status
+
+| Area | Status |
+|------|--------|
+| Upstream sync | Merged through upstream@HEAD (2024) |
+| Shift-JIS CMaps | Added |
+| UCS-2 BE CMaps | Added |
+| GBK CMaps | Added |
+| Big5-ETen CMaps | Added |
+| UHC/EUC-KR CMaps | Added |
+| Upstream PRs incorporated | #37, #42, #45 |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: BSD 3-Clause](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](LICENSE)
 [![Go Reference](https://pkg.go.dev/badge/github.com/Detective-XH/pdf.svg)](https://pkg.go.dev/github.com/Detective-XH/pdf)
+[![Go Report Card](https://goreportcard.com/badge/github.com/Detective-XH/pdf)](https://goreportcard.com/report/github.com/Detective-XH/pdf)
 
 A Go library for reading PDF files, with active CJK text extraction support.
 
@@ -10,27 +11,22 @@ Original lineage: [rsc/pdf](https://github.com/rsc/pdf).
 
 ## Features
 
-- Plain text extraction (no formatting)
+- Plain text extraction with context/cancellation support
 - Styled text extraction (font name, size, position)
 - Text grouped by row
-- **CJK predefined CMap decoders** (added in this fork):
+- Document metadata API (`/Info` dict: title, author, dates, …)
+- Outline (table of contents) with resolved page numbers
+- **CJK predefined CMap decoders**:
   - Japanese Shift-JIS (`90ms-RKSJ-H/V`, `90pv-RKSJ-H`)
   - CJK UCS-2 BE (`UniGB-UCS2-H/V`, `UniCNS-UCS2-H/V`, `UniJIS-UCS2-H/V`, `UniKS-UCS2-H/V`)
-  - Simplified Chinese GBK (`GBK-EUC-H/V`)
-  - Traditional Chinese Big5-ETen (`ETen-B5-H/V`)
-  - Korean UHC/EUC-KR (`KSCms-UHC-H/V`)
+  - Simplified Chinese GBK / GB-EUC / GBKp-EUC (`GBK-EUC-H/V`, `GB-EUC-H/V`, `GBKp-EUC-H/V`)
+  - Traditional Chinese Big5-ETen / ETenms (`ETen-B5-H/V`, `ETenms-B5-H/V`)
+  - Korean UHC / KSC-EUC / UHC-HW (`KSCms-UHC-H/V`, `KSC-EUC-H/V`, `KSCms-UHC-HW-H/V`)
 
 ## Install
 
 ```bash
 go get github.com/Detective-XH/pdf
-```
-
-To use this fork in a project that already depends on `ledongthuc/pdf`, add a
-`replace` directive:
-
-```
-replace github.com/ledongthuc/pdf => github.com/Detective-XH/pdf v0.0.0-latest
 ```
 
 ## Examples
@@ -44,9 +40,10 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 func main() {
@@ -57,7 +54,7 @@ func main() {
 	defer f.Close()
 
 	var buf bytes.Buffer
-	b, err := r.GetPlainText()
+	b, err := r.GetPlainText(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -72,9 +69,10 @@ func main() {
 package main
 
 import (
+	"context"
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 func main() {
@@ -84,7 +82,7 @@ func main() {
 	}
 	defer f.Close()
 
-	sentences, err := r.GetStyledTexts()
+	sentences, err := r.GetStyledTexts(context.Background())
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +102,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 func main() {
@@ -138,7 +136,10 @@ func main() {
 | Upstream sync | Merged through upstream@HEAD (2024) |
 | Shift-JIS CMaps | Added |
 | UCS-2 BE CMaps | Added |
-| GBK CMaps | Added |
-| Big5-ETen CMaps | Added |
-| UHC/EUC-KR CMaps | Added |
-| Upstream PRs incorporated | #37, #42, #45 |
+| GBK / GB-EUC / GBKp-EUC CMaps | Added |
+| Big5-ETen / ETenms CMaps | Added |
+| UHC / KSC-EUC / UHC-HW CMaps | Added |
+| Metadata API (`r.Info()`) | Added |
+| Outline page numbers (`Outline.Page`) | Added |
+| Context / cancellation | Added |
+| Upstream PRs incorporated | #37, #42, #45, #58, #61, #63, #64, #66 |

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,158 @@
+package pdf
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+)
+
+// triggerCtx is a context.Context whose Done() channel is open for the first
+// `limit` calls and closed on subsequent calls. This makes the in-loop
+// `select { case <-ctx.Done(): ... default: }` deterministically fire after
+// exactly `limit` per-page checks, without relying on goroutine timing.
+type triggerCtx struct {
+	mu     sync.Mutex
+	limit  int
+	polls  int
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newTriggerCtx(limit int) *triggerCtx {
+	return &triggerCtx{limit: limit, closed: make(chan struct{})}
+}
+
+func (c *triggerCtx) Done() <-chan struct{} {
+	c.mu.Lock()
+	c.polls++
+	fired := c.polls > c.limit
+	c.mu.Unlock()
+	if fired {
+		c.once.Do(func() { close(c.closed) })
+		return c.closed
+	}
+	return make(chan struct{}) // open channel; select takes default
+}
+
+func (c *triggerCtx) Err() error {
+	select {
+	case <-c.closed:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c *triggerCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *triggerCtx) Value(_ any) any              { return nil }
+
+func TestGetPlainTextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	data := buildMinimalPDF("")
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	_, err = r.GetPlainText(ctx)
+	if err != context.Canceled {
+		t.Errorf("GetPlainText with cancelled ctx: got %v, want context.Canceled", err)
+	}
+}
+
+func TestGetStyledTextsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	data := buildMinimalPDF("")
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	_, err = r.GetStyledTexts(ctx)
+	if err != context.Canceled {
+		t.Errorf("GetStyledTexts with cancelled ctx: got %v, want context.Canceled", err)
+	}
+}
+
+func TestGetPlainTextBackground(t *testing.T) {
+	data := buildMinimalPDF("")
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	result, err := r.GetPlainText(context.Background())
+	if err != nil {
+		t.Errorf("GetPlainText with Background ctx: unexpected error %v", err)
+	}
+	if result == nil {
+		t.Error("GetPlainText with Background ctx: got nil reader")
+	}
+}
+
+func TestGetStyledTextsBackground(t *testing.T) {
+	data := buildMinimalPDF("")
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	_, err = r.GetStyledTexts(context.Background())
+	if err != nil {
+		t.Errorf("GetStyledTexts with Background ctx: unexpected error %v", err)
+	}
+}
+
+// TestGetPlainTextMidwayCancelled verifies that the in-loop select fires:
+// page 1 is allowed through (limit=1 → first Done() call returns open channel),
+// page 2 triggers cancellation (second Done() call returns closed channel).
+func TestGetPlainTextMidwayCancelled(t *testing.T) {
+	data := buildOutlinePDF(3, "", 0, 0)
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	if got := r.NumPage(); got != 3 {
+		t.Fatalf("fixture NumPage = %d, want 3", got)
+	}
+	// limit=1: page 1's Done() call (poll 1) returns open → continues;
+	// page 2's Done() call (poll 2) returns closed → returns context.Canceled.
+	ctx := newTriggerCtx(1)
+	_, err = r.GetPlainText(ctx)
+	if err != context.Canceled {
+		t.Errorf("GetPlainText midway: got %v, want context.Canceled", err)
+	}
+}
+
+// TestGetStyledTextsMidwayCancelled mirrors TestGetPlainTextMidwayCancelled
+// for GetStyledTexts.
+func TestGetStyledTextsMidwayCancelled(t *testing.T) {
+	data := buildOutlinePDF(3, "", 0, 0)
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	if got := r.NumPage(); got != 3 {
+		t.Fatalf("fixture NumPage = %d, want 3", got)
+	}
+	ctx := newTriggerCtx(1)
+	_, err = r.GetStyledTexts(ctx)
+	if err != context.Canceled {
+		t.Errorf("GetStyledTexts midway: got %v, want context.Canceled", err)
+	}
+}
+
+func TestGetPlainTextReturnsReader(t *testing.T) {
+	data := buildOutlinePDF(1, "", 0, 0)
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	result, err := r.GetPlainText(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := io.ReadAll(result); err != nil {
+		t.Errorf("reading result: %v", err)
+	}
+}

--- a/examples/read_plain_text/main.go
+++ b/examples/read_plain_text/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/Detective-XH/pdf"
@@ -17,7 +18,7 @@ func main() {
 	defer f.Close()
 
 	var buf bytes.Buffer
-	b, err := r.GetPlainText()
+	b, err := r.GetPlainText(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/read_plain_text/main.go
+++ b/examples/read_plain_text/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 func main() {

--- a/examples/read_text_with_styles/main.go
+++ b/examples/read_text_with_styles/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Detective-XH/pdf"
@@ -13,7 +14,7 @@ func main() {
 	}
 	defer f.Close()
 
-	sentences, err := r.GetStyledTexts()
+	sentences, err := r.GetStyledTexts(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/read_text_with_styles/main.go
+++ b/examples/read_text_with_styles/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/Detective-XH/pdf
 
-go 1.24.1
+go 1.25.0
+
+require golang.org/x/text v0.37.0

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ledongthuc/pdf
+module github.com/Detective-XH/pdf
 
 go 1.24.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.37.0 h1:Cqjiwd9eSg8e0QAkyCaQTNHFIIzWtidPahFWR83rTrc=
+golang.org/x/text v0.37.0/go.mod h1:a5sjxXGs9hsn/AJVwuElvCAo9v8QYLzvavO5z2PiM38=

--- a/lex.go
+++ b/lex.go
@@ -428,8 +428,8 @@ func (b *buffer) readObject() object {
 			return b.readDict()
 		case "[":
 			return b.readArray()
-		case ">>":
-			// stop the object
+		case ">>", "]":
+			// stop the object - these mark the end of dict/array
 			return nil
 		}
 		b.errorf("unexpected keyword %q parsing object", kw)
@@ -476,7 +476,7 @@ func (b *buffer) readArray() object {
 	var x array
 	for {
 		tok := b.readToken()
-		if tok == nil || tok == keyword("]") {
+		if tok == nil || tok == io.EOF || tok == keyword("]") {
 			break
 		}
 		b.unreadToken(tok)

--- a/lex.go
+++ b/lex.go
@@ -30,6 +30,8 @@ type name string
 // such as "<<", ">>", "[", "]", "{", "}", are also treated as keywords.
 type keyword string
 
+const maxObjectDepth = 1000
+
 // A buffer holds buffered input bytes from the PDF file.
 type buffer struct {
 	r           io.Reader // source of data
@@ -45,6 +47,7 @@ type buffer struct {
 	key         []byte
 	useAES      bool
 	objptr      objptr
+	depth       int
 }
 
 // newBuffer returns a new buffer reading from r at the given offset.
@@ -409,6 +412,13 @@ type objdef struct {
 }
 
 func (b *buffer) readObject() object {
+	b.depth++
+	defer func() { b.depth-- }()
+	if b.depth > maxObjectDepth {
+		b.errorf("object nesting exceeds maximum depth %d", maxObjectDepth)
+		return nil
+	}
+
 	tok := b.readToken()
 	if kw, ok := tok.(keyword); ok {
 		switch kw {

--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,121 @@
+package pdf
+
+import (
+	"strconv"
+	"time"
+)
+
+// Info wraps the /Info dictionary of a PDF document.
+type Info struct {
+	V Value
+}
+
+// Info returns the document's information dictionary.
+func (r *Reader) Info() Info {
+	return Info{r.Trailer().Key("Info")}
+}
+
+func (i Info) Title() string    { return i.V.Key("Title").Text() }
+func (i Info) Author() string   { return i.V.Key("Author").Text() }
+func (i Info) Subject() string  { return i.V.Key("Subject").Text() }
+func (i Info) Keywords() string { return i.V.Key("Keywords").Text() }
+func (i Info) Creator() string  { return i.V.Key("Creator").Text() }
+func (i Info) Producer() string { return i.V.Key("Producer").Text() }
+func (i Info) Trapped() string  { return i.V.Key("Trapped").Name() }
+
+func (i Info) CreationDate() time.Time { return parsePDFDate(i.V.Key("CreationDate").RawString()) }
+func (i Info) ModDate() time.Time      { return parsePDFDate(i.V.Key("ModDate").RawString()) }
+
+// parsePDFDate parses a PDF date string per spec §14.3.3.
+// Format: D:YYYYMMDDHHmmSSOHH'mm' where O is +/-/Z and all fields after YYYY are optional.
+// Returns zero time on empty input or parse failure.
+func parsePDFDate(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	if len(s) >= 2 && s[:2] == "D:" {
+		s = s[2:]
+	}
+	if len(s) < 4 {
+		return time.Time{}
+	}
+	year, err := strconv.Atoi(s[:4])
+	if err != nil {
+		return time.Time{}
+	}
+	s = s[4:]
+
+	month := 1
+	if len(s) >= 2 {
+		if v, err := strconv.Atoi(s[:2]); err == nil {
+			month = v
+			s = s[2:]
+		}
+	}
+	day := 1
+	if len(s) >= 2 {
+		if v, err := strconv.Atoi(s[:2]); err == nil {
+			day = v
+			s = s[2:]
+		}
+	}
+	hour := 0
+	if len(s) >= 2 {
+		if v, err := strconv.Atoi(s[:2]); err == nil {
+			hour = v
+			s = s[2:]
+		}
+	}
+	min := 0
+	if len(s) >= 2 {
+		if v, err := strconv.Atoi(s[:2]); err == nil {
+			min = v
+			s = s[2:]
+		}
+	}
+	sec := 0
+	if len(s) >= 2 {
+		if v, err := strconv.Atoi(s[:2]); err == nil {
+			sec = v
+			s = s[2:]
+		}
+	}
+
+	loc := time.UTC
+	if len(s) >= 1 {
+		switch s[0] {
+		case 'Z':
+			loc = time.UTC
+		case '+', '-':
+			sign := 1
+			if s[0] == '-' {
+				sign = -1
+			}
+			s = s[1:]
+			tzHour := 0
+			if len(s) >= 2 {
+				if v, err := strconv.Atoi(s[:2]); err == nil {
+					tzHour = v
+					s = s[2:]
+				}
+			}
+			if len(s) >= 1 && s[0] == '\'' {
+				s = s[1:]
+			}
+			tzMin := 0
+			if len(s) >= 2 {
+				if v, err := strconv.Atoi(s[:2]); err == nil {
+					tzMin = v
+				}
+			}
+			offset := sign * (tzHour*3600 + tzMin*60)
+			if offset == 0 {
+				loc = time.UTC
+			} else {
+				loc = time.FixedZone("", offset)
+			}
+		}
+	}
+
+	return time.Date(year, time.Month(month), day, hour, min, sec, 0, loc)
+}

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -1,0 +1,143 @@
+package pdf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParsePDFDate(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantZero bool
+		wantRFC  string
+	}{
+		{
+			input:   "D:20231015143000+05'30'",
+			wantRFC: "2023-10-15T14:30:00+05:30",
+		},
+		{
+			input:   "D:20231015143000Z",
+			wantRFC: "2023-10-15T14:30:00Z",
+		},
+		{
+			input:   "D:20231015143000-08'00'",
+			wantRFC: "2023-10-15T14:30:00-08:00",
+		},
+		{
+			input:   "D:20231015",
+			wantRFC: "2023-10-15T00:00:00Z",
+		},
+		{
+			input:   "D:2023",
+			wantRFC: "2023-01-01T00:00:00Z",
+		},
+		{
+			input:    "",
+			wantZero: true,
+		},
+		{
+			input:    "garbage",
+			wantZero: true,
+		},
+		{
+			input:   "20231015143000Z",
+			wantRFC: "2023-10-15T14:30:00Z",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parsePDFDate(tt.input)
+			if tt.wantZero {
+				if !got.IsZero() {
+					t.Errorf("parsePDFDate(%q) = %v, want zero time", tt.input, got)
+				}
+				return
+			}
+			if got.Format(time.RFC3339) != tt.wantRFC {
+				t.Errorf("parsePDFDate(%q) = %v, want %v", tt.input, got.Format(time.RFC3339), tt.wantRFC)
+			}
+		})
+	}
+}
+
+func buildMinimalPDF(infoContent string) []byte {
+	objs := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [] /Count 0 >>",
+	}
+	if infoContent != "" {
+		objs = append(objs, "<< "+infoContent+" >>")
+	}
+
+	var b strings.Builder
+	b.WriteString("%PDF-1.4\n")
+	off := make([]int, len(objs)+1)
+	for i, body := range objs {
+		off[i+1] = b.Len()
+		fmt.Fprintf(&b, "%d 0 obj %s endobj\n", i+1, body)
+	}
+	xrefOff := b.Len()
+	n := len(objs) + 1
+	fmt.Fprintf(&b, "xref\n0 %d\n0000000000 65535 f \n", n)
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&b, "%010d 00000 n \n", off[i])
+	}
+	root := "/Root 1 0 R"
+	if infoContent != "" {
+		root += fmt.Sprintf(" /Info %d 0 R", len(objs))
+	}
+	fmt.Fprintf(&b, "trailer\n<< /Size %d %s >>\nstartxref\n%d\n%%%%EOF\n", n, root, xrefOff)
+	return []byte(b.String())
+}
+
+func TestInfoFields(t *testing.T) {
+	infoContent := "/Title (Test Title) /Author (Test Author) /Subject (Test Subject) /Keywords (foo bar) /Creator (TestApp) /Producer (TestProducer) /CreationDate (D:20231015143000Z)"
+	data := buildMinimalPDF(infoContent)
+
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+
+	info := r.Info()
+	if info.V.IsNull() {
+		t.Fatal("Info.V is null, expected a valid Info dict")
+	}
+	if got := info.Title(); got != "Test Title" {
+		t.Errorf("Title() = %q, want %q", got, "Test Title")
+	}
+	if got := info.Author(); got != "Test Author" {
+		t.Errorf("Author() = %q, want %q", got, "Test Author")
+	}
+	if got := info.Subject(); got != "Test Subject" {
+		t.Errorf("Subject() = %q, want %q", got, "Test Subject")
+	}
+	if got := info.Keywords(); got != "foo bar" {
+		t.Errorf("Keywords() = %q, want %q", got, "foo bar")
+	}
+	if got := info.Creator(); got != "TestApp" {
+		t.Errorf("Creator() = %q, want %q", got, "TestApp")
+	}
+	if got := info.Producer(); got != "TestProducer" {
+		t.Errorf("Producer() = %q, want %q", got, "TestProducer")
+	}
+
+	wantDate := "2023-10-15T14:30:00Z"
+	if got := info.CreationDate().Format(time.RFC3339); got != wantDate {
+		t.Errorf("CreationDate() = %v, want %v", got, wantDate)
+	}
+}
+
+func TestInfoNullWhenNoInfo(t *testing.T) {
+	data := buildMinimalPDF("")
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	if !r.Info().V.IsNull() {
+		t.Error("Info().V.IsNull() = false, want true for PDF without /Info")
+	}
+}

--- a/outline_test.go
+++ b/outline_test.go
@@ -1,0 +1,310 @@
+package pdf
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// buildOutlinePDF constructs a minimal valid PDF with numPages real pages
+// and an optional /Outlines tree. destPageNum (1-based) is the page the
+// first outline entry links to via /Dest; pass 0 to omit /Dest.
+// actionPageNum is the page linked via /A /GoTo; pass 0 to omit.
+// If title is empty, no /Outlines entry is included in the catalog.
+//
+// Object layout:
+//   1: /Catalog (Root) — references /Pages 2 0 R and optionally /Outlines N 0 R
+//   2: /Pages node — /Kids [3 0 R … (2+numPages) 0 R] /Count numPages
+//   3 … 2+numPages: individual /Page objects
+//   2+numPages+1: /Outlines root (if title != "")
+//   2+numPages+2: first outline item with /Dest (if destPageNum > 0)
+//   2+numPages+3: second outline item with /A /GoTo (if actionPageNum > 0)
+func buildOutlinePDF(numPages int, title string, destPageNum int, actionPageNum int) []byte {
+	// Build the Kids list for the Pages node (objects 3 … 2+numPages).
+	var kidRefs []string
+	for i := 1; i <= numPages; i++ {
+		kidRefs = append(kidRefs, fmt.Sprintf("%d 0 R", 2+i))
+	}
+	kidsStr := strings.Join(kidRefs, " ")
+
+	// Collect all object bodies in order.
+	// objs[i] is the body for object number i+1.
+	var objs []string
+
+	// We'll patch object 1 (Catalog) after we know the outline object number.
+	// Reserve slot 0 for Catalog (filled in later).
+	objs = append(objs, "") // placeholder for Catalog
+
+	// Object 2: Pages
+	objs = append(objs, fmt.Sprintf("<< /Type /Pages /Kids [%s] /Count %d >>", kidsStr, numPages))
+
+	// Objects 3 … 2+numPages: individual Page objects
+	for i := 1; i <= numPages; i++ {
+		objs = append(objs, "<< /Type /Page /Parent 2 0 R >>")
+	}
+
+	// Now add Outlines objects if title is non-empty.
+	outlineRootObjNum := 0
+	if title != "" {
+		outlineRootObjNum = len(objs) + 1 // next object number
+
+		// Collect child outline item object numbers.
+		var firstChildObjNum int
+		var childObjNums []int
+
+		// Dest item
+		if destPageNum > 0 {
+			childObjNums = append(childObjNums, outlineRootObjNum+1+len(childObjNums))
+		}
+		// Action item
+		if actionPageNum > 0 {
+			childObjNums = append(childObjNums, outlineRootObjNum+1+len(childObjNums))
+		}
+
+		if len(childObjNums) > 0 {
+			firstChildObjNum = childObjNums[0]
+		}
+
+		// Build Outlines root dict
+		if firstChildObjNum > 0 {
+			lastChildObjNum := childObjNums[len(childObjNums)-1]
+			objs = append(objs, fmt.Sprintf("<< /Type /Outlines /First %d 0 R /Last %d 0 R /Count %d >>",
+				firstChildObjNum, lastChildObjNum, len(childObjNums)))
+		} else {
+			objs = append(objs, "<< /Type /Outlines /Count 0 >>")
+		}
+
+		// Build child item objects.
+		// For /Next linking we need to know consecutive item numbers.
+		destItemObjNum := 0
+		actionItemObjNum := 0
+		idx := 0
+		if destPageNum > 0 {
+			destItemObjNum = childObjNums[idx]
+			idx++
+		}
+		if actionPageNum > 0 {
+			actionItemObjNum = childObjNums[idx]
+		}
+
+		// Dest outline item
+		if destPageNum > 0 {
+			pageObjNum := 2 + destPageNum // page N is object 2+N
+			nextStr := ""
+			if actionItemObjNum > 0 {
+				nextStr = fmt.Sprintf(" /Next %d 0 R", actionItemObjNum)
+			}
+			objs = append(objs, fmt.Sprintf(
+				"<< /Title (%s) /Parent %d 0 R /Dest [%d 0 R /XYZ null null null]%s >>",
+				title, outlineRootObjNum, pageObjNum, nextStr))
+		}
+
+		// Action outline item
+		if actionPageNum > 0 {
+			pageObjNum := 2 + actionPageNum
+			prevStr := ""
+			if destItemObjNum > 0 {
+				prevStr = fmt.Sprintf(" /Prev %d 0 R", destItemObjNum)
+			}
+			objs = append(objs, fmt.Sprintf(
+				"<< /Title (%s via action) /Parent %d 0 R /A << /S /GoTo /D [%d 0 R /Fit] >>%s >>",
+				title, outlineRootObjNum, pageObjNum, prevStr))
+		}
+	}
+
+	// Now fill in the Catalog (object 1).
+	if outlineRootObjNum > 0 {
+		objs[0] = fmt.Sprintf("<< /Type /Catalog /Pages 2 0 R /Outlines %d 0 R >>", outlineRootObjNum)
+	} else {
+		objs[0] = "<< /Type /Catalog /Pages 2 0 R >>"
+	}
+
+	// Serialise the PDF.
+	var b strings.Builder
+	b.WriteString("%PDF-1.4\n")
+
+	// Track byte offsets for xref (1-indexed: off[i] is offset for object i).
+	off := make([]int, len(objs)+1)
+	for i, body := range objs {
+		off[i+1] = b.Len()
+		fmt.Fprintf(&b, "%d 0 obj %s endobj\n", i+1, body)
+	}
+
+	xrefOff := b.Len()
+	n := len(objs) + 1 // total objects including free entry 0
+	fmt.Fprintf(&b, "xref\n0 %d\n0000000000 65535 f \n", n)
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&b, "%010d 00000 n \n", off[i])
+	}
+
+	trailerRoot := fmt.Sprintf("/Root 1 0 R")
+	fmt.Fprintf(&b, "trailer\n<< /Size %d %s >>\nstartxref\n%d\n%%%%EOF\n", n, trailerRoot, xrefOff)
+
+	return []byte(b.String())
+}
+
+// buildPDFWithNamedDest constructs a 1-page PDF whose single outline item
+// has /Dest as a Name (not an array). Named dest resolution is deferred;
+// the correct result is Page == 0.
+func buildPDFWithNamedDest() []byte {
+	objs := []string{
+		"<< /Type /Catalog /Pages 2 0 R /Outlines 4 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /Parent 2 0 R >>",
+		"<< /Type /Outlines /First 5 0 R /Last 5 0 R /Count 1 >>",
+		"<< /Title (Named) /Parent 4 0 R /Dest /SomeName >>",
+	}
+	var b strings.Builder
+	b.WriteString("%PDF-1.4\n")
+	off := make([]int, len(objs)+1)
+	for i, body := range objs {
+		off[i+1] = b.Len()
+		fmt.Fprintf(&b, "%d 0 obj %s endobj\n", i+1, body)
+	}
+	xrefOff := b.Len()
+	n := len(objs) + 1
+	fmt.Fprintf(&b, "xref\n0 %d\n0000000000 65535 f \n", n)
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&b, "%010d 00000 n \n", off[i])
+	}
+	fmt.Fprintf(&b, "trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", n, xrefOff)
+	return []byte(b.String())
+}
+
+func TestOutlineNamedDestReturnsZero(t *testing.T) {
+	data := buildPDFWithNamedDest()
+	r, err := OpenBytes(data)
+	if err != nil {
+		t.Fatalf("OpenBytes failed: %v", err)
+	}
+	if got := r.NumPage(); got != 1 {
+		t.Fatalf("NumPage() = %d, want 1", got)
+	}
+	outline := r.Outline()
+	if len(outline.Child) == 0 {
+		t.Fatal("expected at least one outline child")
+	}
+	if got := outline.Child[0].Page; got != 0 {
+		t.Errorf("Child[0].Page = %d, want 0 for named dest", got)
+	}
+}
+
+func TestOutlinePageNumber(t *testing.T) {
+	// ----------------------------------------------------------------
+	// Case 1: explicit /Dest array → correct page number
+	// ----------------------------------------------------------------
+	t.Run("DestArray", func(t *testing.T) {
+		data := buildOutlinePDF(3, "Chapter", 2, 0)
+		r, err := OpenBytes(data)
+		if err != nil {
+			t.Fatalf("OpenBytes failed: %v", err)
+		}
+		// Guard: fixture must have the expected page count.
+		if got := r.NumPage(); got != 3 {
+			t.Fatalf("NumPage() = %d, want 3", got)
+		}
+		outline := r.Outline()
+		if len(outline.Child) != 1 {
+			t.Fatalf("Outline.Child count = %d, want 1", len(outline.Child))
+		}
+		if got := outline.Child[0].Page; got != 2 {
+			t.Errorf("Child[0].Page = %d, want 2", got)
+		}
+		if got := outline.Child[0].Title; got != "Chapter" {
+			t.Errorf("Child[0].Title = %q, want %q", got, "Chapter")
+		}
+	})
+
+	// ----------------------------------------------------------------
+	// Case 2: /A /S /GoTo → correct page number
+	// ----------------------------------------------------------------
+	t.Run("ActionGoTo", func(t *testing.T) {
+		data := buildOutlinePDF(4, "Section", 0, 3)
+		r, err := OpenBytes(data)
+		if err != nil {
+			t.Fatalf("OpenBytes failed: %v", err)
+		}
+		if got := r.NumPage(); got != 4 {
+			t.Fatalf("NumPage() = %d, want 4", got)
+		}
+		outline := r.Outline()
+		if len(outline.Child) != 1 {
+			t.Fatalf("Outline.Child count = %d, want 1", len(outline.Child))
+		}
+		if got := outline.Child[0].Page; got != 3 {
+			t.Errorf("Child[0].Page = %d, want 3", got)
+		}
+	})
+
+	// ----------------------------------------------------------------
+	// Case 3: outline item with no dest → Page == 0
+	// ----------------------------------------------------------------
+	t.Run("NoDest", func(t *testing.T) {
+		data := buildOutlinePDF(2, "NoLink", 0, 0)
+		r, err := OpenBytes(data)
+		if err != nil {
+			t.Fatalf("OpenBytes failed: %v", err)
+		}
+		if got := r.NumPage(); got != 2 {
+			t.Fatalf("NumPage() = %d, want 2", got)
+		}
+		outline := r.Outline()
+		// When title is "NoLink" but destPageNum==0 and actionPageNum==0, the
+		// Outlines root has no children (no child item objects were written).
+		// The root itself has Page==0.
+		if got := outline.Page; got != 0 {
+			t.Errorf("root outline.Page = %d, want 0", got)
+		}
+		if len(outline.Child) != 0 {
+			t.Errorf("Outline.Child count = %d, want 0", len(outline.Child))
+		}
+	})
+
+	// ----------------------------------------------------------------
+	// Case 4: PDF with no /Outlines → empty outline, Page == 0
+	// ----------------------------------------------------------------
+	t.Run("NoOutlines", func(t *testing.T) {
+		data := buildOutlinePDF(1, "", 0, 0)
+		r, err := OpenBytes(data)
+		if err != nil {
+			t.Fatalf("OpenBytes failed: %v", err)
+		}
+		if got := r.NumPage(); got != 1 {
+			t.Fatalf("NumPage() = %d, want 1", got)
+		}
+		outline := r.Outline()
+		if outline.Page != 0 {
+			t.Errorf("outline.Page = %d, want 0", outline.Page)
+		}
+		if outline.Title != "" {
+			t.Errorf("outline.Title = %q, want empty", outline.Title)
+		}
+		if len(outline.Child) != 0 {
+			t.Errorf("outline.Child count = %d, want 0", len(outline.Child))
+		}
+	})
+
+	// ----------------------------------------------------------------
+	// Case 5: both Dest and Action items in the same PDF
+	// ----------------------------------------------------------------
+	t.Run("BothDestAndAction", func(t *testing.T) {
+		data := buildOutlinePDF(5, "Mixed", 1, 4)
+		r, err := OpenBytes(data)
+		if err != nil {
+			t.Fatalf("OpenBytes failed: %v", err)
+		}
+		if got := r.NumPage(); got != 5 {
+			t.Fatalf("NumPage() = %d, want 5", got)
+		}
+		outline := r.Outline()
+		if len(outline.Child) != 2 {
+			t.Fatalf("Outline.Child count = %d, want 2", len(outline.Child))
+		}
+		if got := outline.Child[0].Page; got != 1 {
+			t.Errorf("Child[0].Page = %d, want 1", got)
+		}
+		if got := outline.Child[1].Page; got != 4 {
+			t.Errorf("Child[1].Page = %d, want 4", got)
+		}
+	})
+}

--- a/page.go
+++ b/page.go
@@ -14,6 +14,9 @@ import (
 
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
 )
 
 // A Page represent a single page in a PDF file.
@@ -220,6 +223,12 @@ func (f Font) getEncoder() TextEncoding {
 			"UniJIS-UCS2-H", "UniJIS-UCS2-V",
 			"UniKS-UCS2-H", "UniKS-UCS2-V":
 			return &ucs2BEEncoder{}
+		case "GBK-EUC-H", "GBK-EUC-V":
+			return &multibyteCMapEncoder{simplifiedchinese.GBK}
+		case "ETen-B5-H", "ETen-B5-V":
+			return &multibyteCMapEncoder{traditionalchinese.Big5}
+		case "KSCms-UHC-H", "KSCms-UHC-V":
+			return &multibyteCMapEncoder{korean.EUCKR}
 		default:
 			if DebugOn {
 				println("unknown encoding", enc.Name())

--- a/page.go
+++ b/page.go
@@ -316,6 +316,7 @@ func (e *multibyteCMapEncoder) Decode(raw string) (text string) {
 // Used for predefined CMaps such as UniGB-UCS2-H/V, UniCNS-UCS2-H/V,
 // UniJIS-UCS2-H/V, and UniKS-UCS2-H/V. Each glyph selector is a 2-byte
 // big-endian Unicode code point (e.g. 中 = 0x4E2D). No external dependency needed.
+// UCS-2/BMP-only — no surrogate-pair handling; correct for Uni*-UCS2-* CMaps.
 type ucs2BEEncoder struct{}
 
 func (e *ucs2BEEncoder) Decode(raw string) (text string) {

--- a/page.go
+++ b/page.go
@@ -215,6 +215,11 @@ func (f Font) getEncoder() TextEncoding {
 			return f.charmapEncoding()
 		case "90ms-RKSJ-H", "90ms-RKSJ-V", "90pv-RKSJ-H":
 			return &multibyteCMapEncoder{japanese.ShiftJIS}
+		case "UniGB-UCS2-H", "UniGB-UCS2-V",
+			"UniCNS-UCS2-H", "UniCNS-UCS2-V",
+			"UniJIS-UCS2-H", "UniJIS-UCS2-V",
+			"UniKS-UCS2-H", "UniKS-UCS2-V":
+			return &ucs2BEEncoder{}
 		default:
 			if DebugOn {
 				println("unknown encoding", enc.Name())
@@ -305,6 +310,20 @@ func (e *multibyteCMapEncoder) Decode(raw string) (text string) {
 		return raw
 	}
 	return string(decoded)
+}
+
+// ucs2BEEncoder decodes PDF content-stream bytes encoded as UCS-2 big-endian.
+// Used for predefined CMaps such as UniGB-UCS2-H/V, UniCNS-UCS2-H/V,
+// UniJIS-UCS2-H/V, and UniKS-UCS2-H/V. Each glyph selector is a 2-byte
+// big-endian Unicode code point (e.g. 中 = 0x4E2D). No external dependency needed.
+type ucs2BEEncoder struct{}
+
+func (e *ucs2BEEncoder) Decode(raw string) (text string) {
+	r := make([]rune, 0, len(raw)/2)
+	for i := 0; i+1 < len(raw); i += 2 {
+		r = append(r, rune(uint16(raw[i])<<8|uint16(raw[i+1])))
+	}
+	return string(r)
 }
 
 type byteEncoder struct {

--- a/page.go
+++ b/page.go
@@ -6,6 +6,7 @@ package pdf
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -66,12 +67,21 @@ func (r *Reader) NumPage() int {
 	return int(r.Trailer().Key("Root").Key("Pages").Key("Count").Int64())
 }
 
-// GetPlainText returns all the text in the PDF file
-func (r *Reader) GetPlainText() (reader io.Reader, err error) {
+// GetPlainText returns all the text in the PDF file.
+// The context is checked once per page; cancel it to interrupt processing.
+func (r *Reader) GetPlainText(ctx context.Context) (reader io.Reader, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	pages := r.NumPage()
 	var buf bytes.Buffer
 	fonts := make(map[string]*Font)
 	for i := 1; i <= pages; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		p := r.Page(i)
 		for _, name := range p.Fonts() { // cache fonts so we don't continually parse charmap
 			if _, ok := fonts[name]; !ok {
@@ -88,10 +98,19 @@ func (r *Reader) GetPlainText() (reader io.Reader, err error) {
 	return &buf, nil
 }
 
-// GetStyledTexts returns list all sentences in an array, that are included styles
-func (r *Reader) GetStyledTexts() (sentences []Text, err error) {
+// GetStyledTexts returns list all sentences in an array, that are included styles.
+// The context is checked once per page; cancel it to interrupt processing.
+func (r *Reader) GetStyledTexts(ctx context.Context) (sentences []Text, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	totalPage := r.NumPage()
 	for pageIndex := 1; pageIndex <= totalPage; pageIndex++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		p := r.Page(pageIndex)
 
 		if p.V.IsNull() || p.V.Key("Contents").Kind() == Null {
@@ -235,11 +254,16 @@ func (f Font) getEncoder() TextEncoding {
 			"UniJIS-UCS2-H", "UniJIS-UCS2-V",
 			"UniKS-UCS2-H", "UniKS-UCS2-V":
 			return &ucs2BEEncoder{}
-		case "GBK-EUC-H", "GBK-EUC-V":
+		case "GB-EUC-H", "GB-EUC-V",
+			"GBKp-EUC-H", "GBKp-EUC-V",
+			"GBK-EUC-H", "GBK-EUC-V":
 			return &multibyteCMapEncoder{simplifiedchinese.GBK}
-		case "ETen-B5-H", "ETen-B5-V":
+		case "ETen-B5-H", "ETen-B5-V",
+			"ETenms-B5-H", "ETenms-B5-V":
 			return &multibyteCMapEncoder{traditionalchinese.Big5}
-		case "KSCms-UHC-H", "KSCms-UHC-V":
+		case "KSCms-UHC-H", "KSCms-UHC-V",
+			"KSC-EUC-H", "KSC-EUC-V",
+			"KSCms-UHC-HW-H", "KSCms-UHC-HW-V":
 			return &multibyteCMapEncoder{korean.EUCKR}
 		default:
 			if DebugOn {
@@ -1148,6 +1172,7 @@ func (x TextHorizontal) Less(i, j int) bool {
 // of a document.
 type Outline struct {
 	Title string    // title for this element
+	Page  int       // 1-based page number; 0 if destination cannot be resolved
 	Child []Outline // child elements
 }
 
@@ -1155,14 +1180,54 @@ type Outline struct {
 // The Outline returned is the root of the outline tree and typically has no Title itself.
 // That is, the children of the returned root are the top-level entries in the outline.
 func (r *Reader) Outline() Outline {
-	return buildOutline(r.Trailer().Key("Root").Key("Outlines"))
+	pages := r.buildPageMap()
+	return buildOutline(r.Trailer().Key("Root").Key("Outlines"), pages)
 }
 
-func buildOutline(entry Value) Outline {
+func (r *Reader) buildPageMap() map[uint32]int {
+	m := make(map[uint32]int)
+	n := r.NumPage()
+	for i := 1; i <= n; i++ {
+		p := r.Page(i)
+		if !p.V.IsNull() {
+			m[p.V.ptr.id] = i
+		}
+	}
+	return m
+}
+
+func buildOutline(entry Value, pages map[uint32]int) Outline {
 	var x Outline
 	x.Title = entry.Key("Title").Text()
+	x.Page = resolveOutlineDest(entry, pages)
 	for child := entry.Key("First"); child.Kind() == Dict; child = child.Key("Next") {
-		x.Child = append(x.Child, buildOutline(child))
+		x.Child = append(x.Child, buildOutline(child, pages))
 	}
 	return x
+}
+
+func resolveOutlineDest(entry Value, pages map[uint32]int) int {
+	dest := entry.Key("Dest")
+	if dest.Kind() == Array {
+		return pageFromDestArray(dest, pages)
+	}
+	action := entry.Key("A")
+	if action.Key("S").Name() == "GoTo" {
+		d := action.Key("D")
+		if d.Kind() == Array {
+			return pageFromDestArray(d, pages)
+		}
+	}
+	return 0
+}
+
+func pageFromDestArray(dest Value, pages map[uint32]int) int {
+	if dest.Len() == 0 {
+		return 0
+	}
+	pageVal := dest.Index(0)
+	if n, ok := pages[pageVal.ptr.id]; ok {
+		return n
+	}
+	return 0
 }

--- a/page.go
+++ b/page.go
@@ -206,6 +206,18 @@ func (f Font) Encoder() TextEncoding {
 }
 
 func (f Font) getEncoder() TextEncoding {
+	// Check ToUnicode first - it's the authoritative character mapping
+	// per PDF spec and takes precedence over Encoding
+	toUnicode := f.V.Key("ToUnicode")
+	if toUnicode.Kind() == Stream {
+		if m := readCmap(toUnicode); m != nil {
+			return m
+		}
+		if DebugOn {
+			println("ToUnicode stream failed to parse, falling back to Encoding")
+		}
+	}
+
 	enc := f.V.Key("Encoding")
 	switch enc.Kind() {
 	case Name:
@@ -215,7 +227,7 @@ func (f Font) getEncoder() TextEncoding {
 		case "MacRomanEncoding":
 			return &byteEncoder{&macRomanEncoding}
 		case "Identity-H":
-			return f.charmapEncoding()
+			return &byteEncoder{&pdfDocEncoding}
 		case "90ms-RKSJ-H", "90ms-RKSJ-V", "90pv-RKSJ-H":
 			return &multibyteCMapEncoder{japanese.ShiftJIS}
 		case "UniGB-UCS2-H", "UniGB-UCS2-V",
@@ -233,60 +245,64 @@ func (f Font) getEncoder() TextEncoding {
 			if DebugOn {
 				println("unknown encoding", enc.Name())
 			}
-			return &nopEncoder{}
+			return &byteEncoder{&pdfDocEncoding}
 		}
 	case Dict:
-		return &dictEncoder{enc.Key("Differences")}
+		return newDictEncoder(enc)
 	case Null:
-		return f.charmapEncoding()
+		return &byteEncoder{&pdfDocEncoding}
 	default:
 		if DebugOn {
 			println("unexpected encoding", enc.String())
 		}
-		return &nopEncoder{}
+		return &byteEncoder{&pdfDocEncoding}
 	}
 }
 
-func (f *Font) charmapEncoding() TextEncoding {
-	toUnicode := f.V.Key("ToUnicode")
-	if toUnicode.Kind() == Stream {
-		m := readCmap(toUnicode)
-		if m == nil {
-			return &nopEncoder{}
-		}
-		return m
-	}
-
-	return &byteEncoder{&pdfDocEncoding}
-}
-
+// dictEncoder handles fonts with Encoding dictionaries containing
+// BaseEncoding and/or Differences arrays per PDF spec section 9.6.6.
 type dictEncoder struct {
-	v Value
+	table [256]rune
+}
+
+func newDictEncoder(enc Value) *dictEncoder {
+	e := &dictEncoder{}
+	baseEnc := enc.Key("BaseEncoding")
+	var baseTable *[256]rune
+	switch baseEnc.Name() {
+	case "WinAnsiEncoding":
+		baseTable = &winAnsiEncoding
+	case "MacRomanEncoding":
+		baseTable = &macRomanEncoding
+	default:
+		baseTable = &pdfDocEncoding
+	}
+	copy(e.table[:], baseTable[:])
+
+	diff := enc.Key("Differences")
+	if diff.Kind() == Array {
+		code := -1
+		for j := 0; j < diff.Len(); j++ {
+			x := diff.Index(j)
+			if x.Kind() == Integer {
+				code = int(x.Int64())
+				continue
+			}
+			if x.Kind() == Name && code >= 0 && code < 256 {
+				if r := nameToRune[x.Name()]; r != 0 {
+					e.table[code] = r
+				}
+				code++
+			}
+		}
+	}
+	return e
 }
 
 func (e *dictEncoder) Decode(raw string) (text string) {
 	r := make([]rune, 0, len(raw))
 	for i := 0; i < len(raw); i++ {
-		ch := rune(raw[i])
-		n := -1
-		for j := 0; j < e.v.Len(); j++ {
-			x := e.v.Index(j)
-			if x.Kind() == Integer {
-				n = int(x.Int64())
-				continue
-			}
-			if x.Kind() == Name {
-				if int(raw[i]) == n {
-					r := nameToRune[x.Name()]
-					if r != 0 {
-						ch = r
-						break
-					}
-				}
-				n++
-			}
-		}
-		r = append(r, ch)
+		r = append(r, e.table[raw[i]])
 	}
 	return string(r)
 }

--- a/page.go
+++ b/page.go
@@ -11,6 +11,9 @@ import (
 	"io"
 	"sort"
 	"strings"
+
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/japanese"
 )
 
 // A Page represent a single page in a PDF file.
@@ -210,6 +213,8 @@ func (f Font) getEncoder() TextEncoding {
 			return &byteEncoder{&macRomanEncoding}
 		case "Identity-H":
 			return f.charmapEncoding()
+		case "90ms-RKSJ-H", "90ms-RKSJ-V", "90pv-RKSJ-H":
+			return &multibyteCMapEncoder{japanese.ShiftJIS}
 		default:
 			if DebugOn {
 				println("unknown encoding", enc.Name())
@@ -285,6 +290,21 @@ type nopEncoder struct {
 
 func (e *nopEncoder) Decode(raw string) (text string) {
 	return raw
+}
+
+// multibyteCMapEncoder decodes PDF content-stream bytes using an x/text Encoding.
+// Used for predefined CMaps whose raw bytes are a well-known legacy encoding
+// (e.g. Shift-JIS for 90ms-RKSJ-H). Silently falls back to raw bytes on error.
+type multibyteCMapEncoder struct {
+	enc encoding.Encoding
+}
+
+func (e *multibyteCMapEncoder) Decode(raw string) (text string) {
+	decoded, err := e.enc.NewDecoder().Bytes([]byte(raw))
+	if err != nil {
+		return raw
+	}
+	return string(decoded)
 }
 
 type byteEncoder struct {

--- a/page_cjk_test.go
+++ b/page_cjk_test.go
@@ -1,0 +1,215 @@
+// Copyright 2014 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pdf
+
+import (
+	"testing"
+
+	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/korean"
+	"golang.org/x/text/encoding/simplifiedchinese"
+	"golang.org/x/text/encoding/traditionalchinese"
+)
+
+// TestUCS2BEEncoder verifies that ucs2BEEncoder correctly decodes UCS-2
+// big-endian byte sequences produced by Uni*-UCS2-H/V predefined CMaps.
+func TestUCS2BEEncoder(t *testing.T) {
+	tests := []struct {
+		name string
+		// raw holds two-byte UCS-2 BE pairs for each rune.
+		raw  []byte
+		want string
+	}{
+		{
+			name: "simplified Chinese characters",
+			// 中(0x4E2D) 文(0x6587) 测(0x6D4B) 试(0x8BD5)
+			raw:  []byte{0x4E, 0x2D, 0x65, 0x87, 0x6D, 0x4B, 0x8B, 0xD5},
+			want: "中文测试",
+		},
+		{
+			name: "traditional Chinese characters",
+			// 繁(0x7E41) 體(0x9AD4) 中(0x4E2D) 文(0x6587)
+			raw:  []byte{0x7E, 0x41, 0x9A, 0xD4, 0x4E, 0x2D, 0x65, 0x87},
+			want: "繁體中文",
+		},
+		{
+			name: "Japanese hiragana",
+			// あ(0x3042) い(0x3044) う(0x3046)
+			raw:  []byte{0x30, 0x42, 0x30, 0x44, 0x30, 0x46},
+			want: "あいう",
+		},
+		{
+			name: "Korean hangul",
+			// 한(0xD55C) 국(0xAD6D) 어(0xC5B4)
+			raw:  []byte{0xD5, 0x5C, 0xAD, 0x6D, 0xC5, 0xB4},
+			want: "한국어",
+		},
+		{
+			name: "ASCII via UCS-2",
+			// A(0x0041) B(0x0042)
+			raw:  []byte{0x00, 0x41, 0x00, 0x42},
+			want: "AB",
+		},
+		{
+			name: "empty input",
+			raw:  []byte{},
+			want: "",
+		},
+		{
+			name: "trailing odd byte is ignored",
+			// 中(0x4E2D) + one trailing byte
+			raw:  []byte{0x4E, 0x2D, 0xFF},
+			want: "中",
+		},
+	}
+
+	enc := &ucs2BEEncoder{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("Decode: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMultibyteCMapEncoder_ShiftJIS verifies that multibyteCMapEncoder
+// correctly decodes Shift-JIS bytes produced by 90ms-RKSJ-H/V predefined CMaps.
+func TestMultibyteCMapEncoder_ShiftJIS(t *testing.T) {
+	enc := &multibyteCMapEncoder{japanese.ShiftJIS}
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "Japanese katakana word",
+			// テスト (te-su-to) in Shift-JIS
+			raw:  []byte{0x83, 0x65, 0x83, 0x58, 0x83, 0x67},
+			want: "テスト",
+		},
+		{
+			name: "mixed kanji and hiragana",
+			// 日本語 in Shift-JIS
+			raw:  []byte{0x93, 0xFA, 0x96, 0x7B, 0x8C, 0xEA},
+			want: "日本語",
+		},
+		{
+			name: "empty input",
+			raw:  []byte{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("Decode: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMultibyteCMapEncoder_GBK verifies that multibyteCMapEncoder correctly
+// decodes GBK bytes produced by GBK-EUC-H/V predefined CMaps.
+func TestMultibyteCMapEncoder_GBK(t *testing.T) {
+	enc := &multibyteCMapEncoder{simplifiedchinese.GBK}
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "simplified Chinese characters",
+			// 中(0xD6D0) 国(0xB9FA) 你(0xC4E3) 好(0xBAC3) in GBK
+			raw:  []byte{0xD6, 0xD0, 0xB9, 0xFA, 0xC4, 0xE3, 0xBA, 0xC3},
+			want: "中国你好",
+		},
+		{
+			name: "empty input",
+			raw:  []byte{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("Decode: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMultibyteCMapEncoder_Big5 verifies that multibyteCMapEncoder correctly
+// decodes Big5-ETen bytes produced by ETen-B5-H/V predefined CMaps.
+func TestMultibyteCMapEncoder_Big5(t *testing.T) {
+	enc := &multibyteCMapEncoder{traditionalchinese.Big5}
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "traditional Chinese characters",
+			// 癒(0xC2A1) 體(0xC5E9) 中(0xA4A4) 文(0xA4E5) in Big5-ETen
+			raw:  []byte{0xC2, 0xA1, 0xC5, 0xE9, 0xA4, 0xA4, 0xA4, 0xE5},
+			want: "癒體中文",
+		},
+		{
+			name: "empty input",
+			raw:  []byte{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("Decode: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMultibyteCMapEncoder_UHC verifies that multibyteCMapEncoder correctly
+// decodes EUC-KR/UHC bytes produced by KSCms-UHC-H/V predefined CMaps.
+func TestMultibyteCMapEncoder_UHC(t *testing.T) {
+	enc := &multibyteCMapEncoder{korean.EUCKR}
+
+	tests := []struct {
+		name string
+		raw  []byte
+		want string
+	}{
+		{
+			name: "Korean characters",
+			// 안(0xBEC8) 녕(0xB3E7) 하(0xC7CF) 펲(0xBC84) 퓭(0xBF94) in EUC-KR
+			raw:  []byte{0xBE, 0xC8, 0xB3, 0xE7, 0xC7, 0xCF, 0xBC, 0x84, 0xBF, 0x94},
+			want: "안녕하펲퓭",
+		},
+		{
+			name: "empty input",
+			raw:  []byte{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("Decode: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/page_cjk_test.go
+++ b/page_cjk_test.go
@@ -213,3 +213,80 @@ func TestMultibyteCMapEncoder_UHC(t *testing.T) {
 		})
 	}
 }
+
+func TestMultibyteCMapEncoder_GBEUC(t *testing.T) {
+	// Bytes sourced from Python: '中文'.encode('gb2312') = [0xd6,0xd0,0xce,0xc4]
+	// GB2312 is a strict subset of GBK — same byte layout for these chars
+	enc := &multibyteCMapEncoder{simplifiedchinese.GBK}
+	tests := []struct{ name string; raw []byte; want string }{
+		{
+			name: "GB-EUC: 中文 via GB2312 bytes",
+			raw:  []byte{0xd6, 0xd0, 0xce, 0xc4},
+			want: "中文",
+		},
+		{
+			name: "GBKp-EUC: same bytes are GBKp-compatible",
+			raw:  []byte{0xd6, 0xd0, 0xce, 0xc4},
+			want: "中文",
+		},
+		{name: "empty", raw: []byte{}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultibyteCMapEncoder_ETenmsB5(t *testing.T) {
+	// Bytes sourced from Python: '中文'.encode('big5') = [0xa4,0xa4,0xa4,0xe5]
+	// ETenms differs from ETen only in punctuation range 0xA1A1-0xA1FE;
+	// main character blocks are identical
+	enc := &multibyteCMapEncoder{traditionalchinese.Big5}
+	tests := []struct{ name string; raw []byte; want string }{
+		{
+			name: "ETenms-B5: 中文 via Big5 bytes",
+			raw:  []byte{0xa4, 0xa4, 0xa4, 0xe5},
+			want: "中文",
+		},
+		{name: "empty", raw: []byte{}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMultibyteCMapEncoder_KSCEUC(t *testing.T) {
+	// Bytes sourced from Python: '한국어'.encode('euc-kr') = [0xc7,0xd1,0xb1,0xb9,0xbe,0xee]
+	// KSC 5601 is EUC-KR predecessor; UHC-HW shares same byte encoding
+	enc := &multibyteCMapEncoder{korean.EUCKR}
+	tests := []struct{ name string; raw []byte; want string }{
+		{
+			name: "KSC-EUC: 한국어 via EUC-KR bytes",
+			raw:  []byte{0xc7, 0xd1, 0xb1, 0xb9, 0xbe, 0xee},
+			want: "한국어",
+		},
+		{
+			name: "KSCms-UHC-HW: same encoding",
+			raw:  []byte{0xc7, 0xd1, 0xb1, 0xb9, 0xbe, 0xee},
+			want: "한국어",
+		},
+		{name: "empty", raw: []byte{}, want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := enc.Decode(string(tt.raw))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pdfpasswd/main.go
+++ b/pdfpasswd/main.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/Detective-XH/pdf"
 )
 
 var (

--- a/ps.go
+++ b/ps.go
@@ -56,88 +56,86 @@ func newDict() Value {
 func Interpret(strm Value, do func(stk *Stack, op string)) {
 	var stk Stack
 	var dicts []dict
-	s := strm
-	strmlen := 1
+	var b *buffer
 	if strm.Kind() == Array {
-		strmlen = strm.Len()
-	}
-
-	for i := 0; i < strmlen; i++ {
-		if strm.Kind() == Array {
-			s = strm.Index(i)
+		strmlen := strm.Len()
+		streams := make([]io.Reader, 0, strmlen)
+		for i := 0; i < strmlen; i++ {
+			streams = append(streams, strm.Index(i).Reader())
 		}
+		multiReader := io.MultiReader(streams...)
+		b = newBuffer(multiReader, 0)
+	} else {
+		rd := strm.Reader()
+		b = newBuffer(rd, 0)
+	}
+	b.allowEOF = true
+	b.allowObjptr = false
+	b.allowStream = false
 
-		rd := s.Reader()
-
-		b := newBuffer(rd, 0)
-		b.allowEOF = true
-		b.allowObjptr = false
-		b.allowStream = false
-
-	Reading:
-		for {
-			tok := b.readToken()
-			if tok == io.EOF {
+Reading:
+	for {
+		tok := b.readToken()
+		if tok == io.EOF {
+			break
+		}
+		if kw, ok := tok.(keyword); ok {
+			switch kw {
+			case "null", "[", "]", "<<", ">>":
 				break
-			}
-			if kw, ok := tok.(keyword); ok {
-				switch kw {
-				case "null", "[", "]", "<<", ">>":
-					break
-				default:
-					for i := len(dicts) - 1; i >= 0; i-- {
-						if v, ok := dicts[i][name(kw)]; ok {
-							stk.Push(Value{nil, objptr{}, v})
-							continue Reading
-						}
+			default:
+				for i := len(dicts) - 1; i >= 0; i-- {
+					if v, ok := dicts[i][name(kw)]; ok {
+						stk.Push(Value{nil, objptr{}, v})
+						continue Reading
 					}
-					do(&stk, string(kw))
-					continue
-				case "dict":
-					stk.Pop()
-					stk.Push(Value{nil, objptr{}, make(dict)})
-					continue
-				case "currentdict":
-					if len(dicts) == 0 {
-						panic("no current dictionary")
-					}
-					stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
-					continue
-				case "begin":
-					d := stk.Pop()
-					if d.Kind() != Dict {
-						panic("cannot begin non-dict")
-					}
-					dicts = append(dicts, d.data.(dict))
-					continue
-				case "end":
-					if len(dicts) <= 0 {
-						panic("mismatched begin/end")
-					}
-					dicts = dicts[:len(dicts)-1]
-					continue
-				case "def":
-					if len(dicts) <= 0 {
-						panic("def without open dict")
-					}
-					val := stk.Pop()
-					key, ok := stk.Pop().data.(name)
-					if !ok {
-						// panic(fmt.Sprintf("def of non-name: %+v", stk.Pop().data))
-						// Skip the value if it has key without value
-						continue
-					}
-					dicts[len(dicts)-1][key] = val.data
-					continue
-				case "pop":
-					stk.Pop()
+				}
+				do(&stk, string(kw))
+				continue
+			case "dict":
+				stk.Pop()
+				stk.Push(Value{nil, objptr{}, make(dict)})
+				continue
+			case "currentdict":
+				if len(dicts) == 0 {
+					panic("no current dictionary")
+				}
+				stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
+				continue
+			case "begin":
+				d := stk.Pop()
+				if d.Kind() != Dict {
+					panic("cannot begin non-dict")
+				}
+				dicts = append(dicts, d.data.(dict))
+				continue
+			case "end":
+				if len(dicts) <= 0 {
+					panic("mismatched begin/end")
+				}
+				dicts = dicts[:len(dicts)-1]
+				continue
+			case "def":
+				if len(dicts) <= 0 {
+					panic("def without open dict")
+				}
+				val := stk.Pop()
+				key, ok := stk.Pop().data.(name)
+				if !ok {
+					// panic(fmt.Sprintf("def of non-name: %+v", stk.Pop().data))
+					// Skip the value if it has key without value
 					continue
 				}
+				dicts[len(dicts)-1][key] = val.data
+				continue
+			case "pop":
+				stk.Pop()
+				continue
 			}
-			b.unreadToken(tok)
-			obj := b.readObject()
-			stk.Push(Value{nil, objptr{}, obj})
 		}
+		b.unreadToken(tok)
+		obj := b.readObject()
+		stk.Push(Value{nil, objptr{}, obj})
 	}
 }
 

--- a/read.go
+++ b/read.go
@@ -126,6 +126,11 @@ func NewReader(f io.ReaderAt, size int64) (*Reader, error) {
 	return NewReaderEncrypted(f, size, nil)
 }
 
+// OpenBytes opens a PDF from an in-memory byte slice.
+func OpenBytes(src []byte) (*Reader, error) {
+	return NewReader(bytes.NewReader(src), int64(len(src)))
+}
+
 // NewReaderEncrypted opens a file for reading, using the data in f with the given total size.
 // If the PDF is encrypted, NewReaderEncrypted calls pw repeatedly to obtain passwords
 // to try. If pw returns the empty string, NewReaderEncrypted stops trying to decrypt

--- a/read.go
+++ b/read.go
@@ -135,7 +135,18 @@ func OpenBytes(src []byte) (*Reader, error) {
 // If the PDF is encrypted, NewReaderEncrypted calls pw repeatedly to obtain passwords
 // to try. If pw returns the empty string, NewReaderEncrypted stops trying to decrypt
 // the file and returns an error.
-func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, error) {
+func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (r *Reader, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			r = nil
+			if e, ok := x.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("malformed PDF: %v", x)
+			}
+		}
+	}()
+
 	buf := make([]byte, 10)
 	f.ReadAt(buf, 0)
 	if !bytes.HasPrefix(buf, []byte("%PDF-1.")) || buf[7] < '0' || buf[7] > '7' || buf[8] != '\r' && buf[8] != '\n' {
@@ -157,7 +168,7 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 		return nil, fmt.Errorf("malformed PDF file: missing final startxref")
 	}
 
-	r := &Reader{
+	r = &Reader{
 		f:   f,
 		end: end,
 	}
@@ -171,11 +182,14 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 		return nil, fmt.Errorf("malformed PDF file: startxref not followed by integer")
 	}
 	b = newBuffer(io.NewSectionReader(r.f, startxref, r.end-startxref), startxref)
-	xref, trailerptr, trailer, err := readXref(r, b)
+	var xrefs []xref
+	var trailerptr objptr
+	var trailer dict
+	xrefs, trailerptr, trailer, err = readXref(r, b)
 	if err != nil {
 		return nil, err
 	}
-	r.xref = xref
+	r.xref = xrefs
 	r.trailer = trailer
 	r.trailerptr = trailerptr
 	if trailer["Encrypt"] == nil {

--- a/read.go
+++ b/read.go
@@ -70,7 +70,6 @@ import (
 	"encoding/ascii85"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strconv"
@@ -825,8 +824,12 @@ func (v Value) Reader() io.ReadCloser {
 	if !ok {
 		return &errorReadCloser{fmt.Errorf("stream not present")}
 	}
+	streamLen := v.Key("Length").Int64()
+	if streamLen == 0 {
+		return io.NopCloser(bytes.NewReader(nil))
+	}
 	var rd io.Reader
-	rd = io.NewSectionReader(v.r.f, x.offset, v.Key("Length").Int64())
+	rd = io.NewSectionReader(v.r.f, x.offset, streamLen)
 	if v.r.key != nil {
 		rd = decryptStream(v.r.key, v.r.useAES, x.ptr, rd)
 	}
@@ -845,7 +848,7 @@ func (v Value) Reader() io.ReadCloser {
 		}
 	}
 
-	return ioutil.NopCloser(rd)
+	return io.NopCloser(rd)
 }
 
 func applyFilter(rd io.Reader, name string, param Value) io.Reader {

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,129 @@
+package pdf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadObjectMaxDepth(t *testing.T) {
+	const depth = maxObjectDepth + 100
+	var payload bytes.Buffer
+	for i := 0; i < depth; i++ {
+		payload.WriteString("0 0 obj\n")
+	}
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+	panicked := false
+	var panicMsg string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+				panicMsg = r.(error).Error()
+			}
+		}()
+		b.readObject()
+	}()
+	if !panicked {
+		t.Fatal("expected panic from deeply nested objects, but readObject returned normally")
+	}
+	if !strings.Contains(panicMsg, "maximum depth") {
+		t.Fatalf("expected 'maximum depth' in panic message, got: %s", panicMsg)
+	}
+}
+
+func TestReadDictMaxDepth(t *testing.T) {
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+	if !panicked {
+		t.Fatal("expected panic from deeply nested dicts, but readObject returned normally")
+	}
+}
+
+func TestReadArrayMaxDepth(t *testing.T) {
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("[ ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" ]")
+	}
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+	if !panicked {
+		t.Fatal("expected panic from deeply nested arrays, but readObject returned normally")
+	}
+}
+
+func TestReadObjectNormalDepth(t *testing.T) {
+	var payload bytes.Buffer
+	const depth = 50
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("(hello)")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		obj := b.readObject()
+		if obj == nil {
+			t.Fatal("expected non-nil object from moderately nested dict")
+		}
+	}()
+	if panicked {
+		t.Fatal("unexpected panic from moderately nested dicts")
+	}
+}
+
+func TestNewReaderMaliciousPDF(t *testing.T) {
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.0\n")
+	for i := 0; i < 10_000; i++ {
+		pdf.WriteString("0\n0\nobj\n")
+	}
+	pdf.WriteString("startxref\n0\n%%EOF\n")
+	data := pdf.Bytes()
+	_, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error from malicious PDF, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Four independent additive features from plan F-01, shipped as one unified changeset.

- **F1 — CJK CMap variants**: Add 10 missing CMap names (`GB-EUC-H/V`, `GBKp-EUC-H/V`, `ETenms-B5-H/V`, `KSC-EUC-H/V`, `KSCms-UHC-HW-H/V`) to `getEncoder()`. Test bytes independently sourced via Python `gb2312`/`big5`/`euc-kr` codecs.
- **F2 — Metadata API**: New `Info` struct and `(*Reader).Info()` wrapping `/Info` dictionary. `parsePDFDate` handles all 8 date format variants from PDF spec §14.3.3.
- **F3 — Outline page numbers**: Add `Page int` (1-based) to `Outline` struct. Resolves `/Dest` arrays and `/A /GoTo` actions. Named destinations leave `Page == 0` (deferred).
- **F4 — Context / cancellation**: `(*Reader).GetPlainText(ctx)` and `(*Reader).GetStyledTexts(ctx)`. `triggerCtx` test double proves in-loop `select` fires. Updates `examples/` and README.

## Other changes

- README: fix attribution URL, import paths → `Detective-XH/pdf`, Go Report Card badge, updated features list, remove stale drop-in section
- CI: bump `go-version` `1.24 → 1.25`, add `-race` to test step
- `.gitignore`: add `.claude/`

## Test plan

- [x] `go test -race ./...` green locally
- [ ] CI green on this PR
- [x] Dedicated test files: `page_cjk_test.go`, `metadata_test.go`, `outline_test.go`, `context_test.go`
- [x] Hygiene scan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)