### PR TITLE
Fix tokens split across content streams

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -56,88 +56,85 @@ func newDict() Value {
 func Interpret(strm Value, do func(stk *Stack, op string)) {
 	var stk Stack
 	var dicts []dict
-	s := strm
-	strmlen := 1
+	var rd io.Reader
 	if strm.Kind() == Array {
-		strmlen = strm.Len()
+		readers := make([]io.Reader, 0, strm.Len())
+		for i := 0; i < strm.Len(); i++ {
+			readers = append(readers, strm.Index(i).Reader())
+		}
+		rd = io.MultiReader(readers...)
+	} else {
+		rd = strm.Reader()
 	}
 
-	for i := 0; i < strmlen; i++ {
-		if strm.Kind() == Array {
-			s = strm.Index(i)
+	b := newBuffer(rd, 0)
+	b.allowEOF = true
+	b.allowObjptr = false
+	b.allowStream = false
+
+Reading:
+	for {
+		tok := b.readToken()
+		if tok == io.EOF {
+			break
 		}
-
-		rd := s.Reader()
-
-		b := newBuffer(rd, 0)
-		b.allowEOF = true
-		b.allowObjptr = false
-		b.allowStream = false
-
-	Reading:
-		for {
-			tok := b.readToken()
-			if tok == io.EOF {
+		if kw, ok := tok.(keyword); ok {
+			switch kw {
+			case "null", "[", "]", "<<", ">>":
 				break
-			}
-			if kw, ok := tok.(keyword); ok {
-				switch kw {
-				case "null", "[", "]", "<<", ">>":
-					break
-				default:
-					for i := len(dicts) - 1; i >= 0; i-- {
-						if v, ok := dicts[i][name(kw)]; ok {
-							stk.Push(Value{nil, objptr{}, v})
-							continue Reading
-						}
+			default:
+				for i := len(dicts) - 1; i >= 0; i-- {
+					if v, ok := dicts[i][name(kw)]; ok {
+						stk.Push(Value{nil, objptr{}, v})
+						continue Reading
 					}
-					do(&stk, string(kw))
-					continue
-				case "dict":
-					stk.Pop()
-					stk.Push(Value{nil, objptr{}, make(dict)})
-					continue
-				case "currentdict":
-					if len(dicts) == 0 {
-						panic("no current dictionary")
-					}
-					stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
-					continue
-				case "begin":
-					d := stk.Pop()
-					if d.Kind() != Dict {
-						panic("cannot begin non-dict")
-					}
-					dicts = append(dicts, d.data.(dict))
-					continue
-				case "end":
-					if len(dicts) <= 0 {
-						panic("mismatched begin/end")
-					}
-					dicts = dicts[:len(dicts)-1]
-					continue
-				case "def":
-					if len(dicts) <= 0 {
-						panic("def without open dict")
-					}
-					val := stk.Pop()
-					key, ok := stk.Pop().data.(name)
-					if !ok {
-						// panic(fmt.Sprintf("def of non-name: %+v", stk.Pop().data))
-						// Skip the value if it has key without value
-						continue
-					}
-					dicts[len(dicts)-1][key] = val.data
-					continue
-				case "pop":
-					stk.Pop()
+				}
+				do(&stk, string(kw))
+				continue
+			case "dict":
+				stk.Pop()
+				stk.Push(Value{nil, objptr{}, make(dict)})
+				continue
+			case "currentdict":
+				if len(dicts) == 0 {
+					panic("no current dictionary")
+				}
+				stk.Push(Value{nil, objptr{}, dicts[len(dicts)-1]})
+				continue
+			case "begin":
+				d := stk.Pop()
+				if d.Kind() != Dict {
+					panic("cannot begin non-dict")
+				}
+				dicts = append(dicts, d.data.(dict))
+				continue
+			case "end":
+				if len(dicts) <= 0 {
+					panic("mismatched begin/end")
+				}
+				dicts = dicts[:len(dicts)-1]
+				continue
+			case "def":
+				if len(dicts) <= 0 {
+					panic("def without open dict")
+				}
+				val := stk.Pop()
+				key, ok := stk.Pop().data.(name)
+				if !ok {
+					// panic(fmt.Sprintf("def of non-name: %+v", stk.Pop().data))
+					// Skip the value if it has key without value
 					continue
 				}
+				dicts[len(dicts)-1][key] = val.data
+				continue
+			case "pop":
+				stk.Pop()
+				continue
 			}
-			b.unreadToken(tok)
-			obj := b.readObject()
-			stk.Push(Value{nil, objptr{}, obj})
 		}
+		b.unreadToken(tok)
+		obj := b.readObject()
+		stk.Push(Value{nil, objptr{}, obj})
 	}
 }
 

--- a/ps_test.go
+++ b/ps_test.go
@@ -1,0 +1,52 @@
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestInterpretContinuesTokensAcrossContentStreams(t *testing.T) {
+	pdfData := splitTextArrayPDF()
+	reader, err := NewReader(bytes.NewReader(pdfData), int64(len(pdfData)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := reader.Page(1).GetPlainText(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(text); got != "Hello world" {
+		t.Fatalf("text = %q, want %q", got, "Hello world")
+	}
+}
+
+func splitTextArrayPDF() []byte {
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 7)
+	writeObject := func(number int, body string) {
+		offsets[number] = pdf.Len()
+		fmt.Fprintf(&pdf, "%d 0 obj\n%s\nendobj\n", number, body)
+	}
+	writeStream := func(number int, content string) {
+		writeObject(number, fmt.Sprintf("<< /Length %d >>\nstream\n%s\nendstream", len(content)+1, content))
+	}
+
+	writeObject(1, "<< /Type /Catalog /Pages 2 0 R >>")
+	writeObject(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+	writeObject(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 6 0 R >> >> /Contents [4 0 R 5 0 R] >>")
+	writeStream(4, "BT /F1 12 Tf 20 100 Td [(Hello)")
+	writeStream(5, "( world)] TJ ET")
+	writeObject(6, "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+	xrefOffset := pdf.Len()
+	pdf.WriteString("xref\n0 7\n0000000000 65535 f \n")
+	for number := 1; number <= 6; number++ {
+		fmt.Fprintf(&pdf, "%010d 00000 n \n", offsets[number])
+	}
+	fmt.Fprintf(&pdf, "trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", xrefOffset)
+	return pdf.Bytes()
+}


### PR DESCRIPTION
## Problem

Text extraction can loop indefinitely when a page uses an array of content streams and a PDF object starts in one stream and finishes in the next.

This was found while processing an otherwise readable PDF whose page `/Contents` entry contains two streams. Other PDF implementations completed the document, but `Page.GetPlainText` in this package consumed CPU without returning.

## Synthetic test case

The added regression test constructs a minimal, one-page, six-object PDF entirely in memory. The page declares:

```text
/Contents [4 0 R 5 0 R]
```

The first content stream starts a `TJ` array:

```text
BT /F1 12 Tf 20 100 Td [(Hello)
```

The second stream completes that array and invokes the operator:

```text
( world)] TJ ET
```

The expected extracted text is `Hello world`. No real-world or user-provided PDF is included in the test.

## Evidence of failure

On `master` at `5959a4027728`, with only the regression test added, this command does not complete normally:

```text
go test -run TestInterpretContinuesTokensAcrossContentStreams -count=1 -timeout=2s
```

It terminates at the test timeout with the active stack in:

```text
buffer.readArray
buffer.readObject
Interpret
Page.GetPlainText
TestInterpretContinuesTokensAcrossContentStreams
```

This reproduces the non-progress condition without the original document.

## Root cause analysis

`Interpret` recognizes that a PDF stream value may be an array, but it currently creates a new `buffer` (lexer) for each array element. The first buffer reaches end-of-stream while `readArray` is still parsing the incomplete `TJ` array. Because the remainder of the array is only available through the next buffer, the current parser cannot make progress.

A page content-stream array is one logical content sequence: its streams are interpreted in order as though concatenated. Lexical state therefore needs to be preserved across each stream boundary.

## Proposed fix

For an array value, collect the ordered stream readers into one `io.MultiReader`, then create one `buffer` over that combined reader. A single stream continues to use its existing reader. The stack and interpreter behavior are otherwise unchanged.

This lets `readArray` continue into the second stream, after which the regression test completes and extracts `Hello world`.

## Validation

- Confirmed the new focused test times out on the unpatched revision.
- Confirmed the focused test passes with this change.
- Confirmed `go test ./...` passes with this change.
- The repository has no additional contribution or PR-template instructions; its CI runs dependency download, `go test -v ./...`, and `go build -v ./...` on Go 1.24.
