### PR TITLE
Fix infinite loop / unbounded allocation in readArray on truncated PDFs

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -466,7 +466,12 @@ func (b *buffer) readArray() object {
 	var x array
 	for {
 		tok := b.readToken()
-		if tok == nil || tok == keyword("]") {
+		// Break on io.EOF as well (readToken returns io.EOF as a token value
+		// once the input is exhausted, and readDict already guards for it):
+		// otherwise an array that is never closed, e.g. in a truncated
+		// content stream, loops forever appending io.EOF objects and
+		// allocates memory without bound.
+		if tok == nil || tok == io.EOF || tok == keyword("]") {
 			break
 		}
 		b.unreadToken(tok)

--- a/lex_test.go
+++ b/lex_test.go
@@ -1,0 +1,69 @@
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+)
+
+// buildUnterminatedArrayPDF constructs a minimal single-page PDF whose
+// content stream ends inside an array that is never closed. Real-world
+// truncated or malformed PDFs exhibit the same shape: the tokenizer hits
+// end of input while readArray is still collecting elements.
+func buildUnterminatedArrayPDF() []byte {
+	var buf bytes.Buffer
+	offsets := make([]int, 5)
+
+	buf.WriteString("%PDF-1.4\n")
+
+	// The content stream ends inside "[ ... " with no closing "]".
+	content := "BT /F1 12 Tf [ (hello) 1 2"
+	objs := []string{
+		"1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n",
+		"2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n",
+		"3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << >> /Contents 4 0 R >>\nendobj\n",
+		fmt.Sprintf("4 0 obj\n<< /Length %d >>\nstream\n%s\nendstream\nendobj\n", len(content), content),
+	}
+	for i, obj := range objs {
+		offsets[i+1] = buf.Len()
+		buf.WriteString(obj)
+	}
+
+	xrefOffset := buf.Len()
+	buf.WriteString("xref\n0 5\n")
+	buf.WriteString("0000000000 65535 f \n")
+	for i := 1; i <= 4; i++ {
+		fmt.Fprintf(&buf, "%010d 00000 n \n", offsets[i])
+	}
+	buf.WriteString("trailer\n<< /Size 5 /Root 1 0 R >>\nstartxref\n")
+	fmt.Fprintf(&buf, "%d\n%%%%EOF\n", xrefOffset)
+	return buf.Bytes()
+}
+
+// TestUnterminatedArrayTerminates verifies that text extraction terminates
+// on a PDF whose content stream is truncated inside an unterminated array.
+// Before readArray handled io.EOF, readToken returned io.EOF as a token
+// value, which matched neither nil nor keyword("]"), so readArray appended
+// io.EOF objects forever, allocating memory without bound.
+func TestUnterminatedArrayTerminates(t *testing.T) {
+	data := buildUnterminatedArrayPDF()
+	r, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// The extracted text is irrelevant; the call just has to return.
+		r.GetPlainText()
+	}()
+
+	select {
+	case <-done:
+		// ok: extraction terminated
+	case <-time.After(5 * time.Second):
+		t.Fatal("GetPlainText did not return within 5s: readArray is looping on io.EOF at end of a truncated content stream")
+	}
+}


### PR DESCRIPTION
## The bug

`buffer.readArray` in `lex.go` loops reading tokens until it sees `nil` or `keyword("]")`:

```go
for {
    tok := b.readToken()
    if tok == nil || tok == keyword("]") {
        break
    }
    b.unreadToken(tok)
    x = append(x, b.readObject())
}
```

When the input is exhausted, `readToken` returns `io.EOF` **as a token value** (`if b.eof { return io.EOF }`), which matches neither break condition. The loop then unreads the `io.EOF` token, `readObject` reads it back and returns it as an object, and it gets appended to the array — forever. Each iteration allocates, so memory grows without bound until the process is OOM-killed.

`readDict` in the same file already has an explicit `io.EOF` guard; `readArray` was missing the equivalent.

## Impact

Any PDF whose content stream is truncated inside an unterminated array (`[` with no closing `]`) hangs every text-extraction entry point: `Reader.GetPlainText`, `Page.GetPlainText`, `Page.Content`, `Page.GetTextByRow`, `Reader.GetStyledTexts` — they all reach `readArray` via `Interpret`. This is not just a theoretical fuzz case: we hit it on a real-world malformed PDF while batch-extracting text from email attachments, and measured roughly 7 GB of heap growth in about 5 seconds before the process was killed.

## The fix

Break out of the loop on `io.EOF` as well, mirroring `readDict`'s handling — a one-line condition change. I audited the other `readToken`/`readObject` loops for the same shape: `readDict` (lex.go) and `Interpret` (ps.go) already break on `io.EOF`, and the loops in read.go either error out on a failed type assertion or are iteration-bounded, so no other changes were needed.

## Regression test

`lex_test.go` synthesizes a minimal single-page PDF entirely in code (no external files) whose content stream ends inside an unterminated array, then runs `GetPlainText` in a goroutine with a 5-second watchdog. The test was verified to fail against unpatched master:

```
=== RUN   TestUnterminatedArrayTerminates
    lex_test.go:67: GetPlainText did not return within 5s: readArray is looping on io.EOF at end of a truncated content stream
--- FAIL: TestUnterminatedArrayTerminates (5.06s)
```

and passes with the fix (returns immediately). `go test ./...` passes.