### PR TITLE
fix: guard debug print behind DebugOn

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -488,7 +488,9 @@ func (b *buffer) readDict() object {
 		}
 		n, ok := tok.(name)
 		if !ok {
-			fmt.Printf("DEBUG: %T(%v)\n. Skip dict", tok, tok)
+			if DebugOn {
+				fmt.Printf("DEBUG: %T(%v)\n. Skip dict", tok, tok)
+			}
 			b.errorf("unexpected non-name key %T(%v) parsing dictionary", tok, tok)
 			continue
 		}


### PR DESCRIPTION
## Summary

Guards a stray debug print behind `DebugOn` flag.