### PR TITLE
fix: ASCII85 decoder drops 'z' zero-groups and never signals EOF at ~> marker

### DIFF
--- a/ascii85.go
+++ b/ascii85.go
@@ -10,44 +10,33 @@ import (
 
 type alphaReader struct {
 	reader io.Reader
+	eod    bool
 }
 
 func newAlphaReader(reader io.Reader) *alphaReader {
 	return &alphaReader{reader: reader}
 }
 
-func checkASCII85(r byte) byte {
-	if r >= '!' && r <= 'u' { // 33 <= ascii85 <=117
-		return r
-	}
-	if r == '~' {
-		return 1 // for marking possible end of data
-	}
-	return 0 // if non-ascii85
+func isASCII85(r byte) bool {
+	return (r >= '!' && r <= 'u') || r == 'z'
 }
 
 func (a *alphaReader) Read(p []byte) (int, error) {
+	if a.eod {
+		return 0, io.EOF
+	}
 	n, err := a.reader.Read(p)
-	if err == io.EOF {
-	}
-	if err != nil {
-		return n, err
-	}
-	buf := make([]byte, n)
-	tilda := false
+	out := 0
 	for i := 0; i < n; i++ {
-		char := checkASCII85(p[i])
-		if char == '>' && tilda { // end of data
-			break
+		c := p[i]
+		if c == '~' {
+			a.eod = true
+			return out, io.EOF
 		}
-		if char > 1 {
-			buf[i] = char
-		}
-		if char == 1 {
-			tilda = true // possible end of data
+		if isASCII85(c) {
+			p[out] = c
+			out++
 		}
 	}
-
-	copy(p, buf)
-	return n, nil
+	return out, err
 }

--- a/ascii85_integration_test.go
+++ b/ascii85_integration_test.go
@@ -1,0 +1,44 @@
+package pdf
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestReadASCII85StreamWithZeroGroup(t *testing.T) {
+	f, r, err := Open("testdata/ascii85_zero_group.pdf")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	contents := r.Page(1).V.Key("Contents")
+	decoded, err := io.ReadAll(contents.Reader())
+	if err != nil {
+		t.Fatalf("read content stream: %v", err)
+	}
+	want := []byte("BT /F1 12 Tf 72 720 Td (Hello ASCII85 A\x00\x00\x00\x00\x00\x00\x00\x00B) Tj ET")
+	if !bytes.Equal(decoded, want) {
+		t.Fatalf("decoded content stream:\n%q\nwant:\n%q", decoded, want)
+	}
+}
+
+func TestReadASCII85FlateChainedStream(t *testing.T) {
+	f, r, err := Open("testdata/ascii85_flate_chain.pdf")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	reader, err := r.GetPlainText()
+	if err != nil {
+		t.Fatalf("GetPlainText: %v", err)
+	}
+	text, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read text: %v", err)
+	}
+	if !strings.Contains(string(text), "Hello chained filters") {
+		t.Fatalf("extracted text %q, want it to contain %q", text, "Hello chained filters")
+	}
+}

--- a/ascii85_test.go
+++ b/ascii85_test.go
@@ -1,0 +1,139 @@
+package pdf
+
+import (
+	"bytes"
+	"encoding/ascii85"
+	"errors"
+	"io"
+	"testing"
+)
+
+var errReadPastEOD = errors.New("read past end of ASCII85 data")
+
+type chunkReader struct {
+	chunks [][]byte
+	err    error
+}
+
+func (r *chunkReader) Read(p []byte) (int, error) {
+	if len(r.chunks) == 0 {
+		return 0, r.err
+	}
+	n := copy(p, r.chunks[0])
+	if n < len(r.chunks[0]) {
+		r.chunks[0] = r.chunks[0][n:]
+	} else {
+		r.chunks = r.chunks[1:]
+	}
+	return n, nil
+}
+
+func encodeASCII85(t *testing.T, src []byte) []byte {
+	t.Helper()
+	dst := make([]byte, ascii85.MaxEncodedLen(len(src)))
+	n := ascii85.Encode(dst, src)
+	return dst[:n]
+}
+
+func decodeThroughAlphaReader(t *testing.T, chunks [][]byte, underlyingErr error) ([]byte, error) {
+	t.Helper()
+	r := newAlphaReader(&chunkReader{chunks: chunks, err: underlyingErr})
+	return io.ReadAll(ascii85.NewDecoder(r))
+}
+
+func TestAlphaReaderPreservesZeroGroups(t *testing.T) {
+	src := []byte("ABCD\x00\x00\x00\x00\x00\x00\x00\x00EFGH")
+	encoded := encodeASCII85(t, src)
+	if !bytes.Contains(encoded, []byte("z")) {
+		t.Fatalf("test setup: encoded form %q must contain 'z' zero-group shorthand", encoded)
+	}
+	stream := append(encoded, "~>"...)
+
+	got, err := decodeThroughAlphaReader(t, [][]byte{stream}, io.EOF)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatalf("decoded %q, want %q", got, src)
+	}
+}
+
+func TestAlphaReaderSignalsEOFAtMarker(t *testing.T) {
+	src := []byte("payload that ends with an explicit EOD marker")
+	encoded := encodeASCII85(t, src)
+	half := len(encoded) / 2
+	chunks := [][]byte{encoded[:half], append(append([]byte{}, encoded[half:]...), "~>"...)}
+
+	got, err := decodeThroughAlphaReader(t, chunks, errReadPastEOD)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatalf("decoded %q, want %q", got, src)
+	}
+}
+
+func TestAlphaReaderMarkerSplitAcrossReads(t *testing.T) {
+	src := []byte("marker split between two reads")
+	encoded := encodeASCII85(t, src)
+	chunks := [][]byte{append(append([]byte{}, encoded...), '~'), []byte(">")}
+
+	got, err := decodeThroughAlphaReader(t, chunks, errReadPastEOD)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatalf("decoded %q, want %q", got, src)
+	}
+}
+
+func TestAlphaReaderIgnoresDataAfterMarker(t *testing.T) {
+	src := []byte("only bytes before the marker count")
+	encoded := encodeASCII85(t, src)
+	stream := append(encoded, "~>\nendstream\nendobj\n"...)
+	chunks := [][]byte{stream, []byte("4 0 obj <</Length 99>>")}
+
+	got, err := decodeThroughAlphaReader(t, chunks, errReadPastEOD)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatalf("decoded %q, want %q", got, src)
+	}
+}
+
+func TestAlphaReaderKeepsWhitespaceHarmless(t *testing.T) {
+	src := []byte("data wrapped across several lines, as PDF generators do")
+	encoded := encodeASCII85(t, src)
+	var wrapped []byte
+	for i, c := range encoded {
+		if i > 0 && i%20 == 0 {
+			wrapped = append(wrapped, '\r', '\n')
+		}
+		wrapped = append(wrapped, c)
+	}
+	wrapped = append(wrapped, "\n~>\n"...)
+
+	got, err := decodeThroughAlphaReader(t, [][]byte{wrapped}, errReadPastEOD)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if !bytes.Equal(got, src) {
+		t.Fatalf("decoded %q, want %q", got, src)
+	}
+}
+
+func TestAlphaReaderReadAfterEOF(t *testing.T) {
+	stream := append(encodeASCII85(t, []byte("tail")), "~>"...)
+	r := newAlphaReader(&chunkReader{chunks: [][]byte{stream}, err: errReadPastEOD})
+	if _, err := io.ReadAll(ascii85.NewDecoder(r)); err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	buf := make([]byte, 16)
+	for i := 0; i < 3; i++ {
+		n, err := r.Read(buf)
+		if n != 0 || err != io.EOF {
+			t.Fatalf("read #%d after EOD: got (%d, %v), want (0, io.EOF)", i+1, n, err)
+		}
+	}
+}

--- a/testdata/ascii85_flate_chain.pdf
+++ b/testdata/ascii85_flate_chain.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 92/Filter[/ASCII85Decode/FlateDecode]>>stream
+GQ@h0!5SU\+92BAz!")%l+>62=+>GVo<+[731*AM20Ha>*+=KclCi"#4@q]:bDIm?$Anc('A
+TDi@+B3(u79"EP%jV~>
+endstream
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000054 00000 n 
+0000000105 00000 n 
+0000000217 00000 n 
+0000000391 00000 n 
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+454
+%%EOF

--- a/testdata/ascii85_zero_group.pdf
+++ b/testdata/ascii85_zero_group.pdf
@@ -1,0 +1,31 @@
+%PDF-1.4
+1 0 obj
+<</Type/Catalog/Pages 2 0 R>>
+endobj
+2 0 obj
+<</Type/Pages/Kids[3 0 R]/Count 1>>
+endobj
+3 0 obj
+<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>
+endobj
+4 0 obj
+<</Length 67/Filter/ASCII85Decode>>stream
+6<#'\7PQ#?1*BP.+?)%u2_m'0<+I+"87cURD]h>E6V0j/2'>0bz!!!!c.3MT)+@T6~>
+endstream
+endobj
+5 0 obj
+<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000054 00000 n 
+0000000105 00000 n 
+0000000217 00000 n 
+0000000352 00000 n 
+trailer
+<</Size 6/Root 1 0 R>>
+startxref
+415
+%%EOF


### PR DESCRIPTION
Fixes #83.

`alphaReader` (the sanitizing reader in front of `encoding/ascii85`) had two bugs:

1. It stripped `z` — the standard ASCII85 shorthand for an all-zero 4-byte group (PDF 32000-1:2008, §7.4.3), emitted by Ghostscript, Adobe tools, and Go's own `ascii85.Encode`. Every `z` silently dropped 4 bytes from the decoded stream: with `[/ASCII85Decode /FlateDecode]` this corrupted the flate stream (`GetPlainText()` → `malformed PDF: unexpected EOF`, `Page.Content()` → panic escaping to the caller); with plain `/ASCII85Decode` the corruption was silent.
2. On the `~>` end-of-data marker it only `break`ed out of the sanitizing loop and returned `n, nil` — it never signaled `io.EOF`, never truncated at the marker, and kept feeding post-marker bytes from later `Read` chunks to the decoder.

The rewritten `Read` filters in place (no per-call allocation), passes `z` through, and returns the sanitized byte count with `io.EOF` as soon as `~` is seen — per spec `~` can only start the EOD marker, which also handles a marker split across two reads for free. After that every `Read` returns `0, io.EOF` without touching the underlying reader.

Tests: 6 unit tests for `alphaReader` (zero-group, EOF at marker, marker split across reads, garbage after marker, line-wrapped input, reads after EOF) and 2 integration tests with minimal synthetic PDFs in `testdata/` — one with a `z` group inside a text string (plain `/ASCII85Decode`), one with an Exstream-style `[/ASCII85Decode /FlateDecode]` chain. Both fixtures are read correctly by poppler's `pdftotext` and Python's `base64.a85decode`, and both failed on the old code.

---

On a separate note: I noticed several open PRs fixing hangs/OOMs (#46, #58, #64, #76, #78, #79) have been waiting for review for a while. I understand maintaining this alone is a lot. I use this library in production for high-volume PDF processing (bank receipts, dozens of layouts) and have a large regression corpus for it — I'd be happy to help with triage and reviews as a co-maintainer if that's useful to you. If you'd rather keep it as is, no problem at all — feel free to just take the fix.
