### PR TITLE
[[MM-70248] Bound plain text extraction to prevent heap exhaustion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,17 @@ name: Go CI
 
 on:
   push:
-    branches: [ "*" ]
+    branches:
+      - master
   pull_request:
-    branches: [ "*" ]
 
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+
+    env:
+      ADVERSARIAL_PDF_DIR: tools/adversarial_pdfs
+      ADVERSARIAL_PDF_SCALE: large
 
     steps:
     - uses: actions/checkout@v4
@@ -24,6 +28,12 @@ jobs:
 
     - name: Run tests
       run: go test -v ./...
+
+    - name: Generate adversarial fixtures
+      run: go run ./tools/gen_adversarial_pdfs -o $ADVERSARIAL_PDF_DIR --scale $ADVERSARIAL_PDF_SCALE
+
+    - name: Run adversarial tests
+      run: go test -v ./... -tags adversarial
 
     - name: Build
       run: go build -v ./... 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Features
 
 ## Install:
 
-`go get -u github.com/ledongthuc/pdf`
+`go get -u github.com/mattermost/pdf`
 
 ## Examples:
 
@@ -26,7 +26,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 func main() {
@@ -57,7 +57,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 func main() {
@@ -94,7 +94,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 func main() {

--- a/adversarial_extract_test.go
+++ b/adversarial_extract_test.go
@@ -1,0 +1,237 @@
+//go:build adversarial
+
+package pdf
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Desired-behavior tests for cancellation / allocation bounds.
+//
+//	go run ./tools/gen_adversarial_pdfs -o tools/adversarial_pdfs --scale medium
+//	go test -tags=adversarial -count=1 -v -run Adversarial .
+//
+// Failures mean the implementation does not yet meet the contract for that
+// fixture (a real gap). Unexpected passes mean the fixture/test missed the
+// predicted path, or the prediction was wrong.
+
+func adversarialDir(t *testing.T) string {
+	t.Helper()
+	dir := os.Getenv("ADVERSARIAL_PDF_DIR")
+	if dir == "" {
+		dir = filepath.Join("tools", "adversarial_pdfs")
+	}
+	if st, err := os.Stat(dir); err != nil || !st.IsDir() {
+		t.Fatalf("missing fixtures dir %s (run `go run ./tools/gen_adversarial_pdfs -o %s` first): %v", dir, dir, err)
+	}
+	return dir
+}
+
+func loadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	scale := os.Getenv("ADVERSARIAL_PDF_SCALE")
+	if scale == "" {
+		scale = "medium"
+	}
+	path := filepath.Join(adversarialDir(t), name+"."+scale+".pdf")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+func extractWithTimeout(t *testing.T, data []byte, timeout time.Duration) (elapsed time.Duration, totalAlloc uint64, err error) {
+	t.Helper()
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	r, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+	}
+
+	start := time.Now()
+	out, err := r.GetPlainText(ctx)
+	elapsed = time.Since(start)
+	if out != nil {
+		_, readErr := io.Copy(io.Discard, out)
+		if err == nil {
+			err = readErr
+		}
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&after)
+	totalAlloc = after.TotalAlloc - before.TotalAlloc
+	return elapsed, totalAlloc, err
+}
+
+// contentStreamTrigger wraps a file's io.ReaderAt and fires once it observes
+// a run of consecutive, sequentially-offset reads — the signature of the
+// lexer streaming through a stream's bytes (the page content, or a ToUnicode
+// CMap it decodes along the way) rather than the scattered small reads used
+// to resolve the xref table, page tree, and font dictionaries. This gives us
+// a deterministic "parsing has begun and content is being consumed" signal
+// to cancel on, instead of racing an arbitrary wall-clock deadline against
+// unrelated setup cost.
+type contentStreamTrigger struct {
+	r io.ReaderAt
+
+	prevEnd   int64
+	runLen    int
+	fired     bool
+	fireTime  time.Time
+	memAtFire runtime.MemStats
+	cancel    context.CancelFunc
+}
+
+// runLenToFire is the number of consecutive sequential reads required before
+// a run is trusted to be real stream consumption rather than coincidental
+// adjacency between unrelated small reads.
+const runLenToFire = 4
+
+func (c *contentStreamTrigger) ReadAt(p []byte, off int64) (int, error) {
+	n, err := c.r.ReadAt(p, off)
+	if !c.fired && n > 0 {
+		if off == c.prevEnd {
+			c.runLen++
+		} else {
+			c.runLen = 1
+		}
+		c.prevEnd = off + int64(n)
+		if c.runLen >= runLenToFire {
+			c.fired = true
+			c.fireTime = time.Now()
+			runtime.ReadMemStats(&c.memAtFire)
+			c.cancel()
+		}
+	}
+	return n, err
+}
+
+// extractWithContentTrigger cancels GetPlainText's context only once an
+// instrumented reader confirms the lexer is mid-stream through real content,
+// then reports cancellation latency and allocations measured from that point
+// forward — not from process start, so CI scheduling noise before parsing
+// begins can't be mistaken for cancellation cost.
+func extractWithContentTrigger(t *testing.T, data []byte) (cancelLatency time.Duration, allocSinceTrigger uint64, err error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	trigger := &contentStreamTrigger{r: bytes.NewReader(data), cancel: cancel}
+	r, err := NewReader(trigger, int64(len(data)))
+	if err != nil {
+		t.Fatalf("NewReader: %v", err)
+	}
+
+	out, err := r.GetPlainText(ctx)
+	if out != nil {
+		_, readErr := io.Copy(io.Discard, out)
+		if err == nil {
+			err = readErr
+		}
+	}
+
+	if !trigger.fired {
+		t.Fatalf("instrumented reader never observed a sequential stream read; fixture/test heuristic mismatch, not a cancellation result")
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	cancelLatency = time.Since(trigger.fireTime)
+	allocSinceTrigger = after.TotalAlloc - trigger.memAtFire.TotalAlloc
+	return cancelLatency, allocSinceTrigger, err
+}
+
+func requireCanceledCheaply(t *testing.T, label string, elapsed time.Duration, alloc uint64, err error, maxElapsed time.Duration, maxAlloc uint64) {
+	t.Helper()
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("%s: want cancel/deadline, got err=%v elapsed=%s alloc=%d", label, err, elapsed, alloc)
+	}
+	if elapsed > maxElapsed {
+		t.Fatalf("%s: cancel too slow: elapsed=%s (want <= %s) alloc=%d", label, elapsed, maxElapsed, alloc)
+	}
+	if alloc > maxAlloc {
+		t.Fatalf("%s: cancel allocated too much: alloc=%d (want <= %d) elapsed=%s", label, alloc, maxAlloc, elapsed)
+	}
+	t.Logf("%s: elapsed=%s alloc=%d err=%v", label, elapsed, alloc, err)
+}
+
+func TestAdversarial_ManyOperatorsCancelsCheaply(t *testing.T) {
+	data := loadFixture(t, "many_operators")
+	elapsed, alloc, err := extractWithContentTrigger(t, data)
+	requireCanceledCheaply(t, "many_operators", elapsed, alloc, err, 5*time.Millisecond, 8<<20)
+}
+
+func TestAdversarial_FlateBombCancelsCheaply(t *testing.T) {
+	data := loadFixture(t, "flate_bomb_tj")
+	elapsed, alloc, err := extractWithContentTrigger(t, data)
+	requireCanceledCheaply(t, "flate_bomb_tj", elapsed, alloc, err, 5*time.Millisecond, 8<<20)
+}
+
+func TestAdversarial_HugeLiteralCancelsCheaply(t *testing.T) {
+	data := loadFixture(t, "huge_literal_tj")
+	elapsed, alloc, err := extractWithContentTrigger(t, data)
+	requireCanceledCheaply(t, "huge_literal_tj", elapsed, alloc, err, 5*time.Millisecond, 8<<20)
+}
+
+func TestAdversarial_ToUnicodeCmapCancelsCheaply(t *testing.T) {
+	data := loadFixture(t, "tounicode_cmap")
+	elapsed, alloc, err := extractWithContentTrigger(t, data)
+	requireCanceledCheaply(t, "tounicode_cmap", elapsed, alloc, err, 5*time.Millisecond, 8<<20)
+}
+
+func TestAdversarial_PredictorColumnsBounded(t *testing.T) {
+	data := loadFixture(t, "predictor_columns")
+	elapsed, alloc, err := extractWithTimeout(t, data, 200*time.Microsecond)
+	// Wanted: reject/cap huge Columns (or honor ctx) without allocating ~2×Columns.
+	if alloc > 8<<20 {
+		t.Fatalf("predictor_columns: allocated %d (want <= 8MiB); err=%v elapsed=%s", alloc, err, elapsed)
+	}
+	if elapsed > 5*time.Millisecond {
+		t.Fatalf("predictor_columns: completed too slowly: elapsed=%s (want <= 5ms); err=%v alloc=%d", elapsed, err, alloc)
+	}
+	t.Logf("predictor_columns: elapsed=%s alloc=%d err=%v", elapsed, alloc, err)
+}
+
+func TestAdversarial_AcroFormStaysCheap(t *testing.T) {
+	data := loadFixture(t, "acroform_fields")
+	elapsed, alloc, err := extractWithTimeout(t, data, 2*time.Second)
+	if err != nil {
+		t.Fatalf("GetPlainText: %v", err)
+	}
+	// Allow up to file size + 2 MiB: xref-table parsing is O(object count)
+	// so the threshold must scale with the fixture, not be a fixed constant.
+	maxAlloc := uint64(len(data)) + 2*(1<<20)
+	if alloc > maxAlloc {
+		t.Fatalf("acroform_fields: unexpectedly expensive alloc=%d (want <= %d) elapsed=%s", alloc, maxAlloc, elapsed)
+	}
+	t.Logf("acroform_fields: elapsed=%s alloc=%d", elapsed, alloc)
+}
+
+func TestAdversarial_NestedContentHitsDepthLimit(t *testing.T) {
+	data := loadFixture(t, "nested_content")
+	_, _, err := extractWithTimeout(t, data, 2*time.Second)
+	if !errors.Is(err, errObjectNestingDepth) {
+		t.Fatalf("nested_content: want nesting-depth error, got %v", err)
+	}
+	t.Logf("nested_content: err=%v", err)
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,172 @@
+package pdf
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// buildMinimalPDF constructs a minimal valid single-page PDF as a byte slice.
+func buildMinimalPDF() []byte {
+	objs := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+		"<< /Type /Page /MediaBox [0 0 100 100] /Parent 2 0 R /Resources << >> >>",
+	}
+
+	var body bytes.Buffer
+	body.WriteString("%PDF-1.0\r\n")
+	offsets := make([]int, len(objs)+1) // 1-indexed
+	for i, content := range objs {
+		offsets[i+1] = body.Len()
+		fmt.Fprintf(&body, "%d 0 obj\n%s\nendobj\n", i+1, content)
+	}
+
+	xrefOffset := body.Len()
+	n := len(objs) + 1
+	fmt.Fprintf(&body, "xref\n0 %d\n", n)
+	fmt.Fprintf(&body, "%010d 65535 f \r\n", 0)
+	for i := 1; i < n; i++ {
+		fmt.Fprintf(&body, "%010d 00000 n \r\n", offsets[i])
+	}
+	fmt.Fprintf(&body, "trailer << /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", n, xrefOffset)
+	return body.Bytes()
+}
+
+// buildMultiPagePDF constructs a minimal valid n-page PDF as a byte slice.
+func buildMultiPagePDF(n int) []byte {
+	// Object layout:
+	//   1: Catalog → 2
+	//   2: Pages, Count=n, Kids=[3..n+2]
+	//   3..n+2: individual Page objects
+	kids := ""
+	for i := 0; i < n; i++ {
+		kids += fmt.Sprintf("%d 0 R ", i+3)
+	}
+	objs := []string{
+		"<< /Type /Catalog /Pages 2 0 R >>",
+		fmt.Sprintf("<< /Type /Pages /Kids [%s] /Count %d >>", kids, n),
+	}
+	for i := 0; i < n; i++ {
+		objs = append(objs, "<< /Type /Page /MediaBox [0 0 100 100] /Parent 2 0 R /Resources << >> >>")
+	}
+
+	var body bytes.Buffer
+	body.WriteString("%PDF-1.0\r\n")
+	offsets := make([]int, len(objs)+1)
+	for i, content := range objs {
+		offsets[i+1] = body.Len()
+		fmt.Fprintf(&body, "%d 0 obj\n%s\nendobj\n", i+1, content)
+	}
+
+	xrefOffset := body.Len()
+	total := len(objs) + 1
+	fmt.Fprintf(&body, "xref\n0 %d\n", total)
+	fmt.Fprintf(&body, "%010d 65535 f \r\n", 0)
+	for i := 1; i < total; i++ {
+		fmt.Fprintf(&body, "%010d 00000 n \r\n", offsets[i])
+	}
+	fmt.Fprintf(&body, "trailer << /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", total, xrefOffset)
+	return body.Bytes()
+}
+
+// triggerCtx is a context.Context whose Done() channel returns open for the
+// first limit calls and a closed channel thereafter, allowing deterministic
+// mid-loop cancellation tests.
+type triggerCtx struct {
+	mu     sync.Mutex
+	limit  int
+	polls  int
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newTriggerCtx(limit int) *triggerCtx {
+	return &triggerCtx{limit: limit, closed: make(chan struct{})}
+}
+
+func (c *triggerCtx) Done() <-chan struct{} {
+	c.mu.Lock()
+	c.polls++
+	fired := c.polls > c.limit
+	c.mu.Unlock()
+	if fired {
+		c.once.Do(func() { close(c.closed) })
+		return c.closed
+	}
+	return make(chan struct{})
+}
+
+func (c *triggerCtx) Err() error {
+	select {
+	case <-c.closed:
+		return context.Canceled
+	default:
+		return nil
+	}
+}
+
+func (c *triggerCtx) Deadline() (time.Time, bool) { return time.Time{}, false }
+func (c *triggerCtx) Value(_ any) any              { return nil }
+
+func TestGetPlainText(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		data    []byte
+		wantErr error
+	}{
+		{name: "pre_cancelled", ctx: cancelledCtx, data: buildMinimalPDF(), wantErr: context.Canceled},
+		{name: "background", ctx: context.Background(), data: buildMinimalPDF()},
+		{name: "midway_cancelled", ctx: newTriggerCtx(1), data: buildMultiPagePDF(3), wantErr: context.Canceled},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewReader(bytes.NewReader(tc.data), int64(len(tc.data)))
+			if err != nil {
+				t.Fatalf("NewReader: %v", err)
+			}
+			result, err := r.GetPlainText(tc.ctx)
+			if err != tc.wantErr {
+				t.Errorf("got %v, want %v", err, tc.wantErr)
+			}
+			if tc.wantErr == nil && result == nil {
+				t.Error("got nil reader")
+			}
+		})
+	}
+}
+
+func TestGetStyledTexts(t *testing.T) {
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		data    []byte
+		wantErr error
+	}{
+		{name: "pre_cancelled", ctx: cancelledCtx, data: buildMinimalPDF(), wantErr: context.Canceled},
+		{name: "background", ctx: context.Background(), data: buildMinimalPDF()},
+		{name: "midway_cancelled", ctx: newTriggerCtx(1), data: buildMultiPagePDF(3), wantErr: context.Canceled},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r, err := NewReader(bytes.NewReader(tc.data), int64(len(tc.data)))
+			if err != nil {
+				t.Fatalf("NewReader: %v", err)
+			}
+			_, err = r.GetStyledTexts(tc.ctx)
+			if err != tc.wantErr {
+				t.Errorf("got %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/examples/read_plain_text/main.go
+++ b/examples/read_plain_text/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/mattermost/pdf"
@@ -17,7 +18,7 @@ func main() {
 	defer f.Close()
 
 	var buf bytes.Buffer
-	b, err := r.GetPlainText()
+	b, err := r.GetPlainText(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/examples/read_plain_text/main.go
+++ b/examples/read_plain_text/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 func main() {

--- a/examples/read_text_with_styles/main.go
+++ b/examples/read_text_with_styles/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 func main() {

--- a/examples/read_text_with_styles/main.go
+++ b/examples/read_text_with_styles/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/mattermost/pdf"
@@ -13,7 +14,7 @@ func main() {
 	}
 	defer f.Close()
 
-	sentences, err := r.GetStyledTexts()
+	sentences, err := r.GetStyledTexts(context.Background())
 	if err != nil {
 		panic(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/ledongthuc/pdf
+module github.com/mattermost/pdf
 
 go 1.24.1

--- a/lex.go
+++ b/lex.go
@@ -30,6 +30,12 @@ type name string
 // such as "<<", ">>", "[", "]", "{", "}", are also treated as keywords.
 type keyword string
 
+// maxObjectDepth is the maximum nesting depth for PDF objects (dicts, arrays,
+// and indirect object definitions). Malicious files can nest millions of
+// "N N obj" tokens to exhaust the Go call stack; this limit turns that into
+// a recoverable panic instead of a fatal process crash.
+const maxObjectDepth = 1000
+
 // A buffer holds buffered input bytes from the PDF file.
 type buffer struct {
 	r           io.Reader // source of data
@@ -45,6 +51,7 @@ type buffer struct {
 	key         []byte
 	useAES      bool
 	objptr      objptr
+	depth       int // current object nesting depth
 }
 
 // newBuffer returns a new buffer reading from r at the given offset.
@@ -409,6 +416,13 @@ type objdef struct {
 }
 
 func (b *buffer) readObject() object {
+	b.depth++
+	defer func() { b.depth-- }()
+	if b.depth > maxObjectDepth {
+		b.errorf("object nesting exceeds maximum depth %d", maxObjectDepth)
+		return nil
+	}
+
 	tok := b.readToken()
 	if kw, ok := tok.(keyword); ok {
 		switch kw {

--- a/lex.go
+++ b/lex.go
@@ -7,6 +7,8 @@
 package pdf
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -36,6 +38,13 @@ type keyword string
 // a recoverable panic instead of a fatal process crash.
 const maxObjectDepth = 1000
 
+// maxStringBytes caps the per-token allocation in readLiteralString and
+// readHexString. Legitimate strings stay well below this; a malicious huge
+// string would otherwise force an unbounded allocation before any cancel poll.
+const maxStringBytes = 128 * 1024 * 1024 // 128 MiB
+
+var errObjectNestingDepth = errors.New("object nesting exceeds maximum depth")
+
 // A buffer holds buffered input bytes from the PDF file.
 type buffer struct {
 	r           io.Reader // source of data
@@ -51,7 +60,8 @@ type buffer struct {
 	key         []byte
 	useAES      bool
 	objptr      objptr
-	depth       int // current object nesting depth
+	depth       int             // current object nesting depth
+	ctx         context.Context // when set, reload polls it so long tokens/streams stay cancellable
 }
 
 // newBuffer returns a new buffer reading from r at the given offset.
@@ -89,6 +99,12 @@ func (b *buffer) errorf(format string, args ...interface{}) {
 }
 
 func (b *buffer) reload() bool {
+	if b.ctx != nil {
+		if err := b.ctx.Err(); err != nil {
+			b.errorf("%w", err)
+			return false
+		}
+	}
 	n := cap(b.buf) - int(b.offset%int64(cap(b.buf)))
 	n, err := b.r.Read(b.buf[:n])
 	if n == 0 && err != nil {
@@ -210,6 +226,9 @@ func (b *buffer) readHexString() token {
 			break
 		}
 		tmp = append(tmp, byte(x))
+		if len(tmp) > maxStringBytes {
+			b.errorf("malformed PDF: hex string exceeds %d bytes", maxStringBytes)
+		}
 	}
 	b.tmp = tmp
 	return string(tmp)
@@ -283,6 +302,9 @@ Loop:
 				}
 				tmp = append(tmp, byte(x))
 			}
+		}
+		if len(tmp) > maxStringBytes {
+			b.errorf("malformed PDF: literal string exceeds %d bytes", maxStringBytes)
 		}
 	}
 	b.tmp = tmp
@@ -419,7 +441,7 @@ func (b *buffer) readObject() object {
 	b.depth++
 	defer func() { b.depth-- }()
 	if b.depth > maxObjectDepth {
-		b.errorf("object nesting exceeds maximum depth %d", maxObjectDepth)
+		b.errorf("%w %d", errObjectNestingDepth, maxObjectDepth)
 		return nil
 	}
 

--- a/page.go
+++ b/page.go
@@ -20,6 +20,8 @@ type Page struct {
 	V Value
 }
 
+const maxTextBytes = 1024 * 1024 * 1 // 1MB
+
 // Page returns the page for the given page number.
 // Page numbers are indexed starting at 1, not 0.
 // If the page is not found, Page returns a Page with p.V.IsNull().
@@ -83,7 +85,11 @@ func (r *Reader) GetPlainText(ctx context.Context) (reader io.Reader, err error)
 				fonts[name] = &f
 			}
 		}
-		text, err := p.GetPlainText(ctx, fonts)
+		remaining := maxTextBytes - int64(buf.Len())
+		if remaining <= 0 {
+			break
+		}
+		text, err := p.GetPlainText(ctx, fonts, remaining)
 		if err != nil {
 			return &bytes.Buffer{}, err
 		}
@@ -559,7 +565,7 @@ type gstate struct {
 // GetPlainText returns the page's all text without format.
 // fonts can be passed in (to improve parsing performance) or left nil.
 // It checks ctx between each PDF operator; cancellation is returned as an error.
-func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result string, err error) {
+func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font, limit int64) (result string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			result = ""
@@ -586,12 +592,33 @@ func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result 
 		}
 	}
 
+	// Interpret polls ctx on every token, so cancelling it when the cap is
+	// reached stops extraction promptly instead of decoding the whole stream.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	capped := false
+
 	var textBuilder bytes.Buffer
 	showText := func(s string) {
+		if capped {
+			return
+		}
 		textBuilder.WriteString(s)
+		if limit > 0 && int64(textBuilder.Len()) >= limit {
+			capped = true
+			cancel()
+		}
 	}
 	showEncodedText := func(s string) {
+		if capped {
+			return
+		}
 		for _, ch := range enc.Decode(s) {
+			if limit > 0 && int64(textBuilder.Len()) >= limit {
+				capped = true
+				cancel()
+				return
+			}
 			_, err := textBuilder.WriteRune(ch)
 			if err != nil {
 				panic(err)
@@ -649,6 +676,10 @@ func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result 
 			}
 		}
 	}); err != nil {
+		// A cap-triggered cancellation is expected; return the partial text.
+		if capped {
+			return textBuilder.String(), nil
+		}
 		return "", err
 	}
 	return textBuilder.String(), nil

--- a/page.go
+++ b/page.go
@@ -6,6 +6,7 @@ package pdf
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -60,12 +61,21 @@ func (r *Reader) NumPage() int {
 	return int(r.Trailer().Key("Root").Key("Pages").Key("Count").Int64())
 }
 
-// GetPlainText returns all the text in the PDF file
-func (r *Reader) GetPlainText() (reader io.Reader, err error) {
+// GetPlainText returns all the text in the PDF file.
+// It checks ctx on each page boundary; callers can cancel mid-extraction.
+func (r *Reader) GetPlainText(ctx context.Context) (reader io.Reader, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	pages := r.NumPage()
 	var buf bytes.Buffer
 	fonts := make(map[string]*Font)
 	for i := 1; i <= pages; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		p := r.Page(i)
 		for _, name := range p.Fonts() { // cache fonts so we don't continually parse charmap
 			if _, ok := fonts[name]; !ok {
@@ -73,7 +83,7 @@ func (r *Reader) GetPlainText() (reader io.Reader, err error) {
 				fonts[name] = &f
 			}
 		}
-		text, err := p.GetPlainText(fonts)
+		text, err := p.GetPlainText(ctx, fonts)
 		if err != nil {
 			return &bytes.Buffer{}, err
 		}
@@ -82,18 +92,30 @@ func (r *Reader) GetPlainText() (reader io.Reader, err error) {
 	return &buf, nil
 }
 
-// GetStyledTexts returns list all sentences in an array, that are included styles
-func (r *Reader) GetStyledTexts() (sentences []Text, err error) {
+// GetStyledTexts returns all styled text runs in the PDF.
+// It checks ctx on each page boundary; callers can cancel mid-extraction.
+func (r *Reader) GetStyledTexts(ctx context.Context) (sentences []Text, err error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	totalPage := r.NumPage()
 	for pageIndex := 1; pageIndex <= totalPage; pageIndex++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
 		p := r.Page(pageIndex)
 
 		if p.V.IsNull() || p.V.Key("Contents").Kind() == Null {
 			continue
 		}
 		var lastTextStyle Text
-		texts := p.Content().Text
-		for _, text := range texts {
+		content, err := p.Content(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, text := range content.Text {
 			if lastTextStyle == (Text{}) {
 				lastTextStyle = text
 				continue
@@ -386,7 +408,7 @@ func readCmap(toUnicode Value) *cmap {
 	n := -1
 	var m cmap
 	ok := true
-	Interpret(toUnicode, func(stk *Stack, op string) {
+	Interpret(context.Background(), toUnicode, func(stk *Stack, op string) {
 		if !ok {
 			return
 		}
@@ -517,8 +539,9 @@ type gstate struct {
 }
 
 // GetPlainText returns the page's all text without format.
-// fonts can be passed in (to improve parsing performance) or left nil
-func (p Page) GetPlainText(fonts map[string]*Font) (result string, err error) {
+// fonts can be passed in (to improve parsing performance) or left nil.
+// It checks ctx between each PDF operator; cancellation is returned as an error.
+func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			result = ""
@@ -554,7 +577,7 @@ func (p Page) GetPlainText(fonts map[string]*Font) (result string, err error) {
 		}
 	}
 
-	Interpret(strm, func(stk *Stack, op string) {
+	if err := Interpret(ctx, strm, func(stk *Stack, op string) {
 		n := stk.Len()
 		args := make([]Value, n)
 		for i := n - 1; i >= 0; i-- {
@@ -603,7 +626,9 @@ func (p Page) GetPlainText(fonts map[string]*Font) (result string, err error) {
 				}
 			}
 		}
-	})
+	}); err != nil {
+		return "", err
+	}
 	return textBuilder.String(), nil
 }
 
@@ -767,7 +792,7 @@ func (p Page) walkTextBlocks(walker func(enc TextEncoding, x, y float64, s strin
 
 	var enc TextEncoding = &nopEncoder{}
 	var currentX, currentY float64
-	Interpret(strm, func(stk *Stack, op string) {
+	_ = Interpret(context.Background(), strm, func(stk *Stack, op string) {
 		n := stk.Len()
 		args := make([]Value, n)
 		for i := n - 1; i >= 0; i-- {
@@ -826,10 +851,11 @@ func (p Page) walkTextBlocks(walker func(enc TextEncoding, x, y float64, s strin
 }
 
 // Content returns the page's content.
-func (p Page) Content() Content {
+// It checks ctx between each PDF operator; cancellation is returned as an error.
+func (p Page) Content(ctx context.Context) (Content, error) {
 	// Handle in case the content page is empty
 	if p.V.IsNull() || p.V.Key("Contents").Kind() == Null {
-		return Content{}
+		return Content{}, nil
 	}
 	strm := p.V.Key("Contents")
 	var enc TextEncoding = &nopEncoder{}
@@ -866,7 +892,7 @@ func (p Page) Content() Content {
 
 	var rect []Rect
 	var gstack []gstate
-	Interpret(strm, func(stk *Stack, op string) {
+	if err := Interpret(ctx, strm, func(stk *Stack, op string) {
 		n := stk.Len()
 		args := make([]Value, n)
 		for i := n - 1; i >= 0; i-- {
@@ -1047,8 +1073,10 @@ func (p Page) Content() Content {
 			}
 			g.Th = args[0].Float64() / 100
 		}
-	})
-	return Content{text, rect}
+	}); err != nil {
+		return Content{}, err
+	}
+	return Content{text, rect}, nil
 }
 
 // TextVertical implements sort.Interface for sorting

--- a/page.go
+++ b/page.go
@@ -215,13 +215,19 @@ func (f Font) Width(code int) float64 {
 
 // Encoder returns the encoding between font code point sequences and UTF-8.
 func (f Font) Encoder() TextEncoding {
+	return f.encoder(context.Background())
+}
+
+// encoder is like Encoder but honors ctx while parsing a ToUnicode CMap, which
+// can be arbitrarily large in a malicious font.
+func (f Font) encoder(ctx context.Context) TextEncoding {
 	if f.enc == nil { // caching the Encoder so we don't have to continually parse charmap
-		f.enc = f.getEncoder()
+		f.enc = f.getEncoder(ctx)
 	}
 	return f.enc
 }
 
-func (f Font) getEncoder() TextEncoding {
+func (f Font) getEncoder(ctx context.Context) TextEncoding {
 	enc := f.V.Key("Encoding")
 	switch enc.Kind() {
 	case Name:
@@ -231,7 +237,7 @@ func (f Font) getEncoder() TextEncoding {
 		case "MacRomanEncoding":
 			return &byteEncoder{&macRomanEncoding}
 		case "Identity-H":
-			return f.charmapEncoding()
+			return f.charmapEncoding(ctx)
 		default:
 			if DebugOn {
 				println("unknown encoding", enc.Name())
@@ -241,7 +247,7 @@ func (f Font) getEncoder() TextEncoding {
 	case Dict:
 		return &dictEncoder{enc.Key("Differences")}
 	case Null:
-		return f.charmapEncoding()
+		return f.charmapEncoding(ctx)
 	default:
 		if DebugOn {
 			println("unexpected encoding", enc.String())
@@ -250,10 +256,10 @@ func (f Font) getEncoder() TextEncoding {
 	}
 }
 
-func (f *Font) charmapEncoding() TextEncoding {
+func (f *Font) charmapEncoding(ctx context.Context) TextEncoding {
 	toUnicode := f.V.Key("ToUnicode")
 	if toUnicode.Kind() == Stream {
-		m := readCmap(toUnicode)
+		m := readCmap(ctx, toUnicode)
 		if m == nil {
 			return &nopEncoder{}
 		}
@@ -404,11 +410,11 @@ Parse:
 	return string(r)
 }
 
-func readCmap(toUnicode Value) *cmap {
+func readCmap(ctx context.Context, toUnicode Value) *cmap {
 	n := -1
 	var m cmap
 	ok := true
-	Interpret(context.Background(), toUnicode, func(stk *Stack, op string) {
+	Interpret(ctx, toUnicode, func(stk *Stack, op string) {
 		if !ok {
 			return
 		}
@@ -432,6 +438,10 @@ func readCmap(toUnicode Value) *cmap {
 				return
 			}
 			for i := 0; i < n; i++ {
+				if err := ctx.Err(); err != nil {
+					ok = false
+					return
+				}
 				hi, lo := stk.Pop().RawString(), stk.Pop().RawString()
 				if len(lo) == 0 || len(lo) != len(hi) {
 					if DebugOn {
@@ -450,6 +460,10 @@ func readCmap(toUnicode Value) *cmap {
 				panic("missing beginbfchar")
 			}
 			for i := 0; i < n; i++ {
+				if err := ctx.Err(); err != nil {
+					ok = false
+					return
+				}
 				repl, orig := stk.Pop().RawString(), stk.Pop().RawString()
 				m.bfchar = append(m.bfchar, bfchar{orig, repl})
 			}
@@ -460,6 +474,10 @@ func readCmap(toUnicode Value) *cmap {
 				panic("missing beginbfrange")
 			}
 			for i := 0; i < n; i++ {
+				if err := ctx.Err(); err != nil {
+					ok = false
+					return
+				}
 				dst, srcHi, srcLo := stk.Pop(), stk.Pop().RawString(), stk.Pop().RawString()
 				m.bfrange = append(m.bfrange, bfrange{srcLo, srcHi, dst})
 			}
@@ -545,7 +563,11 @@ func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result 
 	defer func() {
 		if r := recover(); r != nil {
 			result = ""
-			err = errors.New(fmt.Sprint(r))
+			if recoveredErr, ok := r.(error); ok {
+				err = recoveredErr
+			} else {
+				err = errors.New(fmt.Sprint(r))
+			}
 		}
 	}()
 
@@ -598,7 +620,7 @@ func (p Page) GetPlainText(ctx context.Context, fonts map[string]*Font) (result 
 				panic("bad TL")
 			}
 			if font, ok := fonts[args[0].Name()]; ok {
-				enc = font.Encoder()
+				enc = font.encoder(ctx)
 			} else {
 				enc = &nopEncoder{}
 			}
@@ -852,7 +874,17 @@ func (p Page) walkTextBlocks(walker func(enc TextEncoding, x, y float64, s strin
 
 // Content returns the page's content.
 // It checks ctx between each PDF operator; cancellation is returned as an error.
-func (p Page) Content(ctx context.Context) (Content, error) {
+func (p Page) Content(ctx context.Context) (result Content, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if recoveredErr, ok := r.(error); ok {
+				err = recoveredErr
+			} else {
+				err = errors.New(fmt.Sprint(r))
+			}
+		}
+	}()
+
 	// Handle in case the content page is empty
 	if p.V.IsNull() || p.V.Key("Contents").Kind() == Null {
 		return Content{}, nil
@@ -987,7 +1019,7 @@ func (p Page) Content(ctx context.Context) (Content, error) {
 			}
 			f := args[0].Name()
 			g.Tf = p.Font(f)
-			enc = g.Tf.Encoder()
+			enc = g.Tf.encoder(ctx)
 			if enc == nil {
 				if DebugOn {
 					println("no cmap for", f)

--- a/pdfpasswd/main.go
+++ b/pdfpasswd/main.go
@@ -12,7 +12,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 )
 
 var (

--- a/ps.go
+++ b/ps.go
@@ -5,6 +5,7 @@
 package pdf
 
 import (
+	"context"
 	"fmt"
 	"io"
 )
@@ -53,7 +54,7 @@ func newDict() Value {
 // In the case of a simple stream read only once, otherwise get the length of the stream to handle it properly
 //
 // There is no support for executable blocks, among other limitations.
-func Interpret(strm Value, do func(stk *Stack, op string)) {
+func Interpret(ctx context.Context, strm Value, do func(stk *Stack, op string)) error {
 	var stk Stack
 	var dicts []dict
 	s := strm
@@ -76,6 +77,11 @@ func Interpret(strm Value, do func(stk *Stack, op string)) {
 
 	Reading:
 		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			tok := b.readToken()
 			if tok == io.EOF {
 				break
@@ -139,6 +145,7 @@ func Interpret(strm Value, do func(stk *Stack, op string)) {
 			stk.Push(Value{nil, objptr{}, obj})
 		}
 	}
+	return nil
 }
 
 type seqReader struct {

--- a/ps.go
+++ b/ps.go
@@ -71,6 +71,7 @@ func Interpret(ctx context.Context, strm Value, do func(stk *Stack, op string)) 
 		rd := s.Reader()
 
 		b := newBuffer(rd, 0)
+		b.ctx = ctx
 		b.allowEOF = true
 		b.allowObjptr = false
 		b.allowStream = false

--- a/read.go
+++ b/read.go
@@ -130,7 +130,18 @@ func NewReader(f io.ReaderAt, size int64) (*Reader, error) {
 // If the PDF is encrypted, NewReaderEncrypted calls pw repeatedly to obtain passwords
 // to try. If pw returns the empty string, NewReaderEncrypted stops trying to decrypt
 // the file and returns an error.
-func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, error) {
+func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (r *Reader, err error) {
+	defer func() {
+		if x := recover(); x != nil {
+			r = nil
+			if e, ok := x.(error); ok {
+				err = e
+			} else {
+				err = fmt.Errorf("malformed PDF: %v", x)
+			}
+		}
+	}()
+
 	buf := make([]byte, 10)
 	f.ReadAt(buf, 0)
 	if !bytes.HasPrefix(buf, []byte("%PDF-1.")) || buf[7] < '0' || buf[7] > '7' || buf[8] != '\r' && buf[8] != '\n' {
@@ -152,7 +163,7 @@ func NewReaderEncrypted(f io.ReaderAt, size int64, pw func() string) (*Reader, e
 		return nil, fmt.Errorf("malformed PDF file: missing final startxref")
 	}
 
-	r := &Reader{
+	r = &Reader{
 		f:   f,
 		end: end,
 	}

--- a/read.go
+++ b/read.go
@@ -854,6 +854,12 @@ func applyFilter(rd io.Reader, name string, param Value) io.Reader {
 			return zr
 		}
 		columns := param.Key("Columns").Int64()
+		if columns <= 0 {
+			columns = 1 // PDF spec default when Columns is absent
+		}
+		if columns > maxPredictorColumns {
+			panic(fmt.Errorf("malformed PDF: predictor Columns %d out of range", columns))
+		}
 		switch pred.Int64() {
 		default:
 			if DebugOn {
@@ -878,6 +884,11 @@ func applyFilter(rd io.Reader, name string, param Value) io.Reader {
 		}
 	}
 }
+
+// maxPredictorColumns caps the per-row buffer a Predictor filter allocates.
+// Legitimate rows (image scanlines, xref streams) stay well under this; a
+// malicious huge Columns would otherwise force a ~2×Columns up-front alloc.
+const maxPredictorColumns = 1 << 20
 
 type pngUpReader struct {
 	r    io.Reader

--- a/read_test.go
+++ b/read_test.go
@@ -1,0 +1,153 @@
+package pdf
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestReadObjectMaxDepth(t *testing.T) {
+	// Craft a payload of deeply nested "0 0 obj" sequences that would
+	// previously cause unbounded recursion and a fatal stack overflow.
+	// With the depth limit in place this must produce a recoverable panic
+	// (caught here) instead of crashing the process.
+	const depth = maxObjectDepth + 100
+	var payload bytes.Buffer
+	for i := 0; i < depth; i++ {
+		payload.WriteString("0 0 obj\n")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	var panicMsg string
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+				panicMsg = r.(error).Error()
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested objects, but readObject returned normally")
+	}
+	if !strings.Contains(panicMsg, "maximum depth") {
+		t.Fatalf("expected 'maximum depth' in panic message, got: %s", panicMsg)
+	}
+}
+
+func TestReadDictMaxDepth(t *testing.T) {
+	// Deeply nested dictionaries: << /A << /A << ... >> >> >>
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested dicts, but readObject returned normally")
+	}
+}
+
+func TestReadArrayMaxDepth(t *testing.T) {
+	// Deeply nested arrays: [ [ [ ... ] ] ]
+	var payload bytes.Buffer
+	const depth = maxObjectDepth + 100
+	for i := 0; i < depth; i++ {
+		payload.WriteString("[ ")
+	}
+	payload.WriteString("null")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" ]")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		b.readObject()
+	}()
+
+	if !panicked {
+		t.Fatal("expected panic from deeply nested arrays, but readObject returned normally")
+	}
+}
+
+func TestReadObjectNormalDepth(t *testing.T) {
+	// A moderately nested structure should parse without hitting the limit.
+	var payload bytes.Buffer
+	const depth = 50
+	for i := 0; i < depth; i++ {
+		payload.WriteString("<< /A ")
+	}
+	payload.WriteString("(hello)")
+	for i := 0; i < depth; i++ {
+		payload.WriteString(" >>")
+	}
+
+	b := newBuffer(&payload, 0)
+	b.allowEOF = true
+
+	panicked := false
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				panicked = true
+			}
+		}()
+		obj := b.readObject()
+		if obj == nil {
+			t.Fatal("expected non-nil object from moderately nested dict")
+		}
+	}()
+
+	if panicked {
+		t.Fatal("unexpected panic from moderately nested dicts")
+	}
+}
+
+func TestNewReaderMaliciousPDF(t *testing.T) {
+	// Reproduce the exact attack vector from MM-63434: a PDF with millions
+	// of "0 0 obj" tokens that triggers deep recursion during NewReader's
+	// xref parsing. With the fix, NewReader should return an error (via
+	// recovered panic) rather than crashing the process.
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.0\n")
+	for i := 0; i < 10_000; i++ {
+		pdf.WriteString("0\n0\nobj\n")
+	}
+	pdf.WriteString("startxref\n0\n%%EOF\n")
+
+	data := pdf.Bytes()
+	_, err := NewReader(bytes.NewReader(data), int64(len(data)))
+	if err == nil {
+		t.Fatal("expected error from malicious PDF, got nil")
+	}
+}

--- a/tools/adversarial_pdfs/.gitignore
+++ b/tools/adversarial_pdfs/.gitignore
@@ -1,0 +1,3 @@
+# Regenerable; large scale fixtures are huge.
+*.pdf
+!README.md

--- a/tools/gen_adversarial_pdfs/main.go
+++ b/tools/gen_adversarial_pdfs/main.go
@@ -1,0 +1,317 @@
+// Generate adversarial PDFs that stress cancellation / allocation gaps in mattermost/pdf.
+//
+// Usage:
+//
+//	go run ./tools/gen_adversarial_pdfs -o tools/adversarial_pdfs --scale medium
+//	go run ./tools/gen_adversarial_pdfs -o /tmp/pdfs --scale large many_operators nested_content
+package main
+
+import (
+	"bytes"
+	"compress/zlib"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// --- PDF writing helpers ---
+
+func xrefAndTrailer(body []byte, offsets []int, rootObj int) []byte {
+	xrefPos := len(body)
+	n := len(offsets)
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "xref\n0 %d\n", n)
+	buf.WriteString("0000000000 65535 f \r\n")
+	for _, off := range offsets[1:] {
+		fmt.Fprintf(&buf, "%010d 00000 n \r\n", off)
+	}
+	fmt.Fprintf(&buf, "trailer << /Size %d /Root %d 0 R >>\nstartxref\n%d\n", n, rootObj, xrefPos)
+	buf.WriteString("%%EOF\n")
+	return buf.Bytes()
+}
+
+func writeObjects(objs [][]byte) []byte {
+	var body []byte
+	body = append(body, "%PDF-1.4\n%\xe2\xe3\xcf\xd3\n"...)
+	offsets := make([]int, len(objs))
+	for i := 1; i < len(objs); i++ {
+		offsets[i] = len(body)
+		body = append(body, fmt.Sprintf("%d 0 obj\n", i)...)
+		body = append(body, objs[i]...)
+		body = append(body, "\nendobj\n"...)
+	}
+	return append(body, xrefAndTrailer(body, offsets, 1)...)
+}
+
+func pdfStream(data []byte, extraDict string) []byte {
+	header := fmt.Sprintf("<< /Length %d%s >>\nstream\n", len(data), extraDict)
+	result := make([]byte, 0, len(header)+len(data)+len("\nendstream"))
+	result = append(result, header...)
+	result = append(result, data...)
+	return append(result, "\nendstream"...)
+}
+
+func flateStream(raw []byte, extraDict string) []byte {
+	var buf bytes.Buffer
+	w, _ := zlib.NewWriterLevel(&buf, zlib.BestCompression)
+	_, _ = w.Write(raw)
+	_ = w.Close()
+	return pdfStream(buf.Bytes(), " /Filter /FlateDecode"+extraDict)
+}
+
+func simplePageWithContent(content []byte, useFlate bool) []byte {
+	var contentObj []byte
+	if useFlate {
+		contentObj = flateStream(content, "")
+	} else {
+		contentObj = pdfStream(content, "")
+	}
+	return writeObjects([][]byte{
+		{},
+		[]byte("<< /Type /Catalog /Pages 2 0 R >>"),
+		[]byte("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		[]byte("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"),
+		contentObj,
+		[]byte("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+	})
+}
+
+// --- Fixture builders ---
+
+// buildToUnicodeCmap builds a page whose font has a large ToUnicode CMap.
+// GetPlainText → Tf → Font.Encoder() → readCmap → Interpret(context.Background()),
+// so cancellation of the outer ctx does not stop CMap parsing.
+func buildToUnicodeCmap(bfcharCount int) []byte {
+	var lines []string
+	lines = append(lines,
+		"/CIDInit /ProcSet findresource begin",
+		"12 dict begin",
+		"begincmap",
+		"/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >> def",
+		"/CMapName /Adobe-Identity-UCS def",
+		"/CMapType 2 def",
+		"1 begincodespacerange",
+		"<0000> <FFFF>",
+		"endcodespacerange",
+	)
+	remaining, code := bfcharCount, 0
+	for remaining > 0 {
+		n := min(100, remaining)
+		lines = append(lines, fmt.Sprintf("%d beginbfchar", n))
+		for range n {
+			lines = append(lines, fmt.Sprintf("<%04X> <%02X>", code, code&0xFF))
+			code = (code + 1) & 0xFFFF
+		}
+		lines = append(lines, "endbfchar")
+		remaining -= n
+	}
+	lines = append(lines, "endcmap", "CMapName currentdict /CMap defineresource pop", "end", "end")
+
+	return writeObjects([][]byte{
+		{},
+		[]byte("<< /Type /Catalog /Pages 2 0 R >>"),
+		[]byte("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		[]byte("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"),
+		pdfStream([]byte("BT /F1 12 Tf 10 700 Td (x) Tj ET"), ""),
+		[]byte("<< /Type /Font /Subtype /Type1 /BaseFont /Evil /ToUnicode 6 0 R >>"),
+		flateStream([]byte(strings.Join(lines, "\n")), ""),
+	})
+}
+
+// buildHugeLiteralTj builds a page with a single Tj whose literal string is stringBytes long.
+// Interpret checks ctx only before readToken; readLiteralString appends the entire payload
+// with no further cancel checks.
+func buildHugeLiteralTj(stringBytes int) []byte {
+	content := make([]byte, 0, len("BT /F1 12 Tf 10 700 Td (")+stringBytes+len(") Tj ET"))
+	content = append(content, "BT /F1 12 Tf 10 700 Td ("...)
+	content = append(content, bytes.Repeat([]byte("A"), stringBytes)...)
+	content = append(content, ") Tj ET"...)
+	return simplePageWithContent(content, false)
+}
+
+// buildFlateBombTj builds a small on-disk PDF whose FlateDecode content stream
+// expands into one huge literal Tj string.
+func buildFlateBombTj(expandedBytes int) []byte {
+	content := make([]byte, 0, len("BT /F1 12 Tf 10 700 Td (")+expandedBytes+len(") Tj ET"))
+	content = append(content, "BT /F1 12 Tf 10 700 Td ("...)
+	content = append(content, bytes.Repeat([]byte("A"), expandedBytes)...)
+	content = append(content, ") Tj ET"...)
+	return simplePageWithContent(content, true)
+}
+
+// buildPredictorColumns builds a page whose content stream uses Predictor 12
+// with a huge Columns value. applyFilter allocates hist/tmp of length 1+columns
+// before any Interpret loop.
+func buildPredictorColumns(columns int) []byte {
+	var compressed bytes.Buffer
+	w, _ := zlib.NewWriterLevel(&compressed, zlib.BestCompression)
+	_, _ = w.Write([]byte("q Q\n"))
+	_ = w.Close()
+	extras := fmt.Sprintf(" /Filter /FlateDecode /DecodeParms << /Predictor 12 /Columns %d >>", columns)
+	return writeObjects([][]byte{
+		{},
+		[]byte("<< /Type /Catalog /Pages 2 0 R >>"),
+		[]byte("<< /Type /Pages /Kids [3 0 R] /Count 1 >>"),
+		[]byte("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>"),
+		pdfStream(compressed.Bytes(), extras),
+		[]byte("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>"),
+	})
+}
+
+// buildManyOperators builds a control case: many tiny Tj operators.
+// Cancel should stop between them.
+func buildManyOperators(opCount int) []byte {
+	content := make([]byte, 0, len("BT /F1 12 Tf 10 700 Td")+opCount*len(" (.) Tj")+len(" ET"))
+	content = append(content, "BT /F1 12 Tf 10 700 Td"...)
+	for range opCount {
+		content = append(content, " (.) Tj"...)
+	}
+	content = append(content, " ET"...)
+	return simplePageWithContent(content, false)
+}
+
+// buildAcroformFields builds a page with many AcroForm fields.
+// Negative control: GetPlainText never walks /AcroForm.
+func buildAcroformFields(fieldCount int) []byte {
+	objs := make([][]byte, 7+fieldCount)
+	objs[0] = []byte{}
+
+	refs := make([]string, fieldCount)
+	for i := range fieldCount {
+		refs[i] = fmt.Sprintf("%d 0 R", 7+i)
+	}
+	objs[1] = []byte("<< /Type /Catalog /Pages 2 0 R /AcroForm 6 0 R >>")
+	objs[2] = []byte("<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+	objs[3] = []byte("<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>")
+	objs[4] = pdfStream([]byte("BT /F1 12 Tf 10 700 Td (hello) Tj ET"), "")
+	objs[5] = []byte("<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+	objs[6] = []byte(fmt.Sprintf("<< /Fields [%s] /NeedAppearances true >>", strings.Join(refs, " ")))
+	xs := strings.Repeat("X", 64)
+	for i := range fieldCount {
+		objs[7+i] = []byte(fmt.Sprintf(
+			"<< /FT /Tx /T (field%d) /V (%s) /Rect [0 0 10 10] /Subtype /Widget /Type /Annot >>",
+			i, xs,
+		))
+	}
+	return writeObjects(objs)
+}
+
+// buildNestedContent builds a page whose first content-stream object is deeply nested.
+// Hits maxObjectDepth (1000) when depth is large enough.
+func buildNestedContent(depth int) []byte {
+	content := make([]byte, 0, depth+1+depth+len(" BT /F1 12 Tf 10 700 Td (x) Tj ET"))
+	content = append(content, bytes.Repeat([]byte("["), depth)...)
+	content = append(content, '1')
+	content = append(content, bytes.Repeat([]byte("]"), depth)...)
+	content = append(content, " BT /F1 12 Tf 10 700 Td (x) Tj ET"...)
+	return simplePageWithContent(content, false)
+}
+
+// --- Scales ---
+
+type scaleConfig struct {
+	toUnicodeCmap  int
+	hugeLiteralTj  int
+	flateBombTj    int
+	predictorCols  int
+	manyOperators  int
+	acroformFields int
+	nestedContent  int
+}
+
+var scales = map[string]scaleConfig{
+	"small": {
+		toUnicodeCmap:  2_000,
+		hugeLiteralTj:  1_000_000,
+		flateBombTj:    5_000_000,
+		predictorCols:  5_000_000,
+		manyOperators:  10_000,
+		acroformFields: 1_000,
+		nestedContent:  1_200, // must exceed maxObjectDepth=1000
+	},
+	"medium": {
+		toUnicodeCmap:  50_000,
+		hugeLiteralTj:  16_000_000,
+		flateBombTj:    32_000_000,
+		predictorCols:  16_000_000,
+		manyOperators:  80_000,
+		acroformFields: 10_000,
+		nestedContent:  1_200,
+	},
+	"large": {
+		toUnicodeCmap:  200_000,
+		hugeLiteralTj:  64_000_000,
+		flateBombTj:    256_000_000,
+		predictorCols:  64_000_000,
+		manyOperators:  200_000,
+		acroformFields: 50_000,
+		nestedContent:  1_200,
+	},
+}
+
+type builder struct {
+	name  string
+	build func(scaleConfig) []byte
+}
+
+var builders = []builder{
+	{"tounicode_cmap", func(c scaleConfig) []byte { return buildToUnicodeCmap(c.toUnicodeCmap) }},
+	{"huge_literal_tj", func(c scaleConfig) []byte { return buildHugeLiteralTj(c.hugeLiteralTj) }},
+	{"flate_bomb_tj", func(c scaleConfig) []byte { return buildFlateBombTj(c.flateBombTj) }},
+	{"predictor_columns", func(c scaleConfig) []byte { return buildPredictorColumns(c.predictorCols) }},
+	{"many_operators", func(c scaleConfig) []byte { return buildManyOperators(c.manyOperators) }},
+	{"acroform_fields", func(c scaleConfig) []byte { return buildAcroformFields(c.acroformFields) }},
+	{"nested_content", func(c scaleConfig) []byte { return buildNestedContent(c.nestedContent) }},
+}
+
+func main() {
+	outdir := flag.String("o", "tools/adversarial_pdfs", "output directory")
+	scale := flag.String("scale", "medium", "fixture scale: small, medium, large")
+	flag.Parse()
+
+	cfg, ok := scales[*scale]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "unknown scale %q (want: small, medium, large)\n", *scale)
+		os.Exit(2)
+	}
+
+	if err := os.MkdirAll(*outdir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	selected := flag.Args()
+
+	if len(selected) > 0 {
+		known := make(map[string]bool, len(builders))
+		for _, b := range builders {
+			known[b.name] = true
+		}
+		for _, name := range selected {
+			if !known[name] {
+				fmt.Fprintf(os.Stderr, "unknown fixture %q\n", name)
+				os.Exit(2)
+			}
+		}
+	}
+
+	want := make(map[string]bool, len(selected))
+	for _, name := range selected {
+		want[name] = true
+	}
+
+	for _, b := range builders {
+		if len(want) > 0 && !want[b.name] {
+			continue
+		}
+		data := b.build(cfg)
+		path := filepath.Join(*outdir, b.name+"."+*scale+".pdf")
+		if err := os.WriteFile(path, data, 0o644); err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
+		}
+		fmt.Printf("wrote %s (%d bytes on disk)\n", path, len(data))
+	}
+}


### PR DESCRIPTION
#### Summary
`GetPlainText` accumulated all extracted text into an in-memory buffer with no upper bound. A small PDF whose `FlateDecode` content stream expands into a very large volume of text could therefore drive the heap far beyond the size of the file.

This PR caps total accumulated text at 1 MiB, which is the same value we truncate to on the server. Once the cap is reached, extraction stops appending and cancels the interpreter's context.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70248