### PR TITLE
fix: Interpret should not panic on a malformed CMap PostScript preamble

### DIFF
--- a/ps.go
+++ b/ps.go
@@ -115,10 +115,20 @@ Reading:
 				dicts = dicts[:len(dicts)-1]
 				continue
 			case "def":
-				if len(dicts) <= 0 {
-					panic("def without open dict")
-				}
 				val := stk.Pop()
+				if len(dicts) <= 0 {
+					// A "def" with no dict opened by "begin" is invalid
+					// PostScript, but producers emit it in practice inside a
+					// malformed CMap dictionary LITERAL (e.g.
+					// "<</Registry (x) def/Ordering (y) def>>", where "def"
+					// should not appear between "<<" and ">>" at all). This
+					// package is a limited PostScript subset for embedded
+					// CMap/function data, not a strict validator (see the
+					// doc comment above), so discard the operand and keep
+					// going rather than take the whole Interpret call down
+					// over one producer's malformed dict.
+					continue
+				}
 				key, ok := stk.Pop().data.(name)
 				if !ok {
 					// panic(fmt.Sprintf("def of non-name: %+v", stk.Pop().data))
@@ -133,9 +143,34 @@ Reading:
 			}
 		}
 		b.unreadToken(tok)
-		obj := b.readObject()
+		obj, ok := readObjectRecover(b)
+		if !ok {
+			continue
+		}
 		stk.Push(Value{nil, objptr{}, obj})
 	}
+}
+
+// readObjectRecover reads one object, recovering a panic from malformed
+// input rather than letting it escape Interpret.
+//
+// Interpret parses an embedded PostScript-SUBSET stream (a CMap, a function)
+// that is not always a well-formed PDF object graph — for example, a
+// producer's CMap embedding "def" tokens inside what should be a plain
+// dictionary literal, which readObject (correctly, for a real PDF object)
+// treats as a hard parse error. Letting that escape takes the WHOLE calling
+// operation down — e.g. reading a font's /ToUnicode CMap — over one
+// unparseable operand, even when the caller (readCmap) only needs the
+// recognized cmap operators and the rest of the stream is fine. ok=false
+// means the operand is discarded; the Reading loop continues from wherever
+// the underlying buffer's position landed.
+func readObjectRecover(b *buffer) (obj object, ok bool) {
+	defer func() {
+		if recover() != nil {
+			obj, ok = nil, false
+		}
+	}()
+	return b.readObject(), true
 }
 
 type seqReader struct {

--- a/ps_malformed_cmap_test.go
+++ b/ps_malformed_cmap_test.go
@@ -1,0 +1,94 @@
+package pdf
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// TestInterpretToleratesMalformedCMapPreamble is the regression test for a
+// real-world crash: some font subsetting tools emit a /ToUnicode CMap whose
+// PostScript preamble is malformed — a /CIDSystemInfo dict literal with a
+// stray "def" after every entry, e.g.
+//
+//	<</Registry (Vendor+Subset+0) def/Ordering (T1UV) def/Supplement 0 def>> def
+//
+// which is invalid: a dictionary literal ("<< ... >>") should contain only
+// key/value pairs, never a "def" token between them. Before this fix,
+// Interpret read that literal via readObject, which panicked on the
+// unexpected "def" token while parsing what it expected to be a plain
+// dictionary — and that panic propagated all the way up through readCmap,
+// Font.Encoder, and Page.GetPlainText, failing extraction of the WHOLE page
+// even though the font's own beginbfchar/beginbfrange mapping data (the
+// part GetPlainText actually needs) was itself complete and well-formed.
+//
+// Observed in the wild in an Identity-H font on a real health-insurance
+// plan document's multi-language notice page (one font per language).
+func TestInterpretToleratesMalformedCMapPreamble(t *testing.T) {
+	pdfData := malformedCMapPreamblePDF()
+	reader, err := NewReader(bytes.NewReader(pdfData), int64(len(pdfData)))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := reader.Page(1).GetPlainText(nil)
+	if err != nil {
+		t.Fatalf("GetPlainText returned an error (want the malformed CMap preamble to be tolerated): %v", err)
+	}
+	if got := strings.TrimSpace(text); got != "AB" {
+		t.Fatalf("text = %q, want %q — the font's own bfchar mapping data is well-formed and should still be used", got, "AB")
+	}
+}
+
+// malformedCMapPreamblePDF builds a one-page PDF with a single Identity-H
+// composite font whose /ToUnicode stream's PostScript preamble is malformed
+// in the exact shape observed in the wild (see the test's doc comment), but
+// whose beginbfchar section — the only part GetPlainText's caller actually
+// needs — is well-formed.
+func malformedCMapPreamblePDF() []byte {
+	// Reproduces the real producer's byte-exact preamble shape (verified
+	// against the crashing font's raw /ToUnicode stream): lines separated by
+	// "\r", and the /CIDSystemInfo dict literal carrying a stray "def" after
+	// every entry.
+	toUnicode := "/CIDInit /ProcSet findresource begin\r" +
+		"12 dict begin\r" +
+		"begincmap\r" +
+		"/CIDSystemInfo <<\r" +
+		"/Registry (Vendor+Subset+0) def\r" +
+		"/Ordering (T1UV) def\r" +
+		"/Supplement 0 def\r" +
+		">> def\r" +
+		"/CMapName /Vendor+Subset+0 def\r" +
+		"1 begincodespacerange\r<0000> <FFFF>\rendcodespacerange\r" +
+		"2 beginbfchar\r<0001> <0041>\r<0002> <0042>\rendbfchar\r" +
+		"endcmap\r" +
+		"CMapName currentdict /CMap defineresource pop\r" +
+		"end end"
+
+	var pdf bytes.Buffer
+	pdf.WriteString("%PDF-1.4\n")
+	offsets := make([]int, 7)
+	writeObject := func(number int, body string) {
+		offsets[number] = pdf.Len()
+		fmt.Fprintf(&pdf, "%d 0 obj\n%s\nendobj\n", number, body)
+	}
+	writeStream := func(number int, dict, content string) {
+		writeObject(number, fmt.Sprintf("<< %s /Length %d >>\nstream\n%s\nendstream", dict, len(content), content))
+	}
+
+	writeObject(1, "<< /Type /Catalog /Pages 2 0 R >>")
+	writeObject(2, "<< /Type /Pages /Kids [3 0 R] /Count 1 >>")
+	writeObject(3, "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Resources << /Font << /F1 6 0 R >> >> /Contents 4 0 R >>")
+	writeStream(4, "", "BT /F1 12 Tf <00010002> Tj ET")
+	writeObject(6, "<< /Type /Font /Subtype /Type0 /BaseFont /Vendor+Subset+0 /Encoding /Identity-H /ToUnicode 5 0 R >>")
+	writeStream(5, "", toUnicode)
+
+	xrefOffset := pdf.Len()
+	pdf.WriteString("xref\n0 7\n0000000000 65535 f \n")
+	for number := 1; number <= 6; number++ {
+		fmt.Fprintf(&pdf, "%010d 00000 n \n", offsets[number])
+	}
+	fmt.Fprintf(&pdf, "trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF\n", xrefOffset)
+	return pdf.Bytes()
+}


### PR DESCRIPTION
## Summary

`Interpret` can panic on a broken CMap. `readCmap` calls `Interpret` to read
a font's `/ToUnicode` CMap. A panic in `Interpret` propagates all the way up
to `Page.GetPlainText`. This fails the whole page — even when the font's
real character-mapping data is fine.

## Root cause

Some font subsetting tools write a `/ToUnicode` CMap with a broken preamble.
The preamble is the setup section before the actual character mappings.
Here is a real example of the broken preamble:

```
<</Registry (Vendor+Subset+0) def/Ordering (T1UV) def/Supplement 0 def>> def
```

A dictionary literal (`<< ... >>`) should hold only key/value pairs. It
should never contain a `def` token. `Interpret` reads this literal with
`readObject`. `readObject` correctly treats the stray `def` as a parse
error for a normal PDF object. But `Interpret` has no recovery around that
read, so the panic escapes and propagates up the call chain:

```
readCmap → Font.Encoder → Page.GetPlainText
```

This bug showed up in a real health-insurance plan document. One page had
a multi-language notice, with one font per language. One font's subset had
this broken preamble. The panic failed the whole page. The document's
other pages decoded fine. The page's other fonts also decoded fine.

## Fix

`Interpret`'s own doc comment already says it is not a full-blown
PostScript interpreter, built only to handle a limited PostScript subset
for embedded CMap and font data. This fix keeps to that scope, instead of
adding strict validation:

1. Recover from a panic when `Interpret` reads an operand it does not
   recognize (see `readObjectRecover`). Before this fix, that panic
   escaped `Interpret` uncaught.
2. Do not panic on a `def` operator when no dictionary is open. Before
   this fix, `def` with no open dictionary always panicked. This case can
   happen after fix 1 recovers from a panic in the middle of the preamble.
   The same switch case already skips a `def` with a non-name key instead
   of panicking — this applies the same idea to a `def` with no open
   dictionary.

## Test plan

- Added `TestInterpretToleratesMalformedCMapPreamble`. It uses the exact
  byte shape of the real broken preamble, including its `\r` line endings.
  It checks that `GetPlainText` still reads the font's correct `bfchar`
  mapping data.
  - This test fails on `master`.
  - This test passes with this fix.
- The full existing test suite passes (`go test ./...`). No existing
  behavior changed.
- I confirmed the fix against the real document that surfaced this bug. The page
  that used to fail now extracts cleanly, with no other change needed.
