### PR TITLE
fix(lex): bail readArray on io.EOF to avoid unbounded growth

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -469,6 +469,14 @@ func (b *buffer) readArray() object {
 		if tok == nil || tok == keyword("]") {
 			break
 		}
+		// Bail on io.EOF so a malformed PDF whose content stream
+		// never reaches a closing ']' cannot drive this loop into
+		// unbounded `append` growth (which on some inputs allocates
+		// many GB before OOM-ing the process). readDict already
+		// has the same guard.
+		if tok == io.EOF {
+			break
+		}
 		b.unreadToken(tok)
 		x = append(x, b.readObject())
 	}


### PR DESCRIPTION
Malformed PDFs whose content stream never reaches a closing ']' previously drove (*buffer).readArray into an infinite loop: readToken returns io.EOF, the loop unreads it, calls readObject, which returns the same io.EOF, and the array slice grows by one element per iteration. On some inputs this allocates many GB before the process is OOM-killed.

readDict already has the same io.EOF guard. This change adds the matching guard to readArray.

Reproduced and validated with a content-stream-truncated PDF that previously hung at >30 GB resident memory; with the fix the parse returns cleanly within milliseconds.